### PR TITLE
Add support for TCP port forwarding.

### DIFF
--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -23,6 +23,9 @@ public struct SSHChildChannelOptions {
 
     /// - seealso: `RemoteChannelIdentifierOption`.
     public static let remoteChannelIdentifier: SSHChildChannelOptions.Types.RemoteChannelIdentifierOption = .init()
+
+    /// - seealso: `SSHChannelTypeOption`.
+    public static let sshChannelType: SSHChildChannelOptions.Types.SSHChannelTypeOption = .init()
 }
 
 extension SSHChildChannelOptions {
@@ -40,6 +43,13 @@ extension SSHChildChannelOptions.Types {
     /// `RemoteChannelIdentifierOption` allows users to query the channel number assigned by the remote peer for a given channel.
     public struct RemoteChannelIdentifierOption: ChannelOption {
         public typealias Value = UInt32?
+
+        public init() {}
+    }
+
+    /// `SSHChannelTypeOption` allows users to query the type of the channel they're currently using.
+    public struct SSHChannelTypeOption: ChannelOption {
+        public typealias Value = SSHChannelType
 
         public init() {}
     }

--- a/Sources/NIOSSH/Child Channels/SSHChannelType.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelType.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIO
+
+/// `SSHChannelType` represents the type of a single SSH channel.
+///
+/// SSH Channels are always one of a number of types. The most common type is "session", which
+/// encompasses remote execution of a program, whether that be a single binary, a shell, a subsystem,
+/// or something else.
+///
+/// Other major types include X11 channels (not supported by swift-nio-ssh), direct TCP/IP (for
+/// forwarding a connection from the SSH client to the SSH server) and forwarded TCP/IP (for forwarding
+/// a connection from a socket the server was listening on on behalf the client).
+///
+/// Some channel types have associated metadata. That metadata can be retrieved from SSH channels using
+/// channel options.
+public enum SSHChannelType: Equatable {
+    /// A "session" is remote execution of a program.
+    case session
+
+    /// "Direct TCP/IP" is a request from the client to the server to open an outbound connection.
+    case directTCPIP(DirectTCPIP)
+
+    /// "Forwarded TCP/IP" is a connection that was accepted from a listening socket and is being forwarded to the client.
+    case forwardedTCPIP(ForwardedTCPIP)
+}
+
+extension SSHChannelType {
+    public struct DirectTCPIP: Equatable {
+        /// The target host for the forwarded TCP connection.
+        public var targetHost: String
+
+        /// The target port for the forwarded TCP connection.
+        public var targetPort: Int {
+            get {
+                Int(self._targetPort)
+            }
+            set {
+                self._targetPort = UInt16(newValue)
+            }
+        }
+
+        /// The address of the initiating peer.
+        public var originatorAddress: SocketAddress
+
+        fileprivate private(set) var _targetPort: UInt16
+
+        public init(targetHost: String, targetPort: Int, originatorAddress: SocketAddress) {
+            self.targetHost = targetHost
+            self._targetPort = UInt16(targetPort)
+            self.originatorAddress = originatorAddress
+        }
+
+        internal init(targetHost: String, targetPort: UInt16, originatorAddress: SocketAddress) {
+            self.targetHost = targetHost
+            self._targetPort = targetPort
+            self.originatorAddress = originatorAddress
+        }
+    }
+}
+
+extension SSHChannelType {
+    public struct ForwardedTCPIP: Equatable {
+        /// The host the remote peer connected to. This should be identical to the one that was requested.
+        public var listeningHost: String
+
+        /// The port on which the proxy is listening, and to which the remote peer connected.
+        public var listeningPort: Int {
+            get {
+                Int(self._listeningPort)
+            }
+            set {
+                self._listeningPort = UInt16(newValue)
+            }
+        }
+
+        /// The address of the remote peer.
+        public var originatorAddress: SocketAddress
+
+        fileprivate private(set) var _listeningPort: UInt16
+
+        public init(listeningHost: String, listeningPort: Int, originatorAddress: SocketAddress) {
+            self.originatorAddress = originatorAddress
+            self.listeningHost = listeningHost
+            self._listeningPort = UInt16(listeningPort)
+        }
+
+        internal init(listeningHost: String, listeningPort: UInt16, originatorAddress: SocketAddress) {
+            self.originatorAddress = originatorAddress
+            self.listeningHost = listeningHost
+            self._listeningPort = listeningPort
+        }
+    }
+}
+
+extension SSHChannelType {
+    internal init(_ message: SSHMessage.ChannelOpenMessage) {
+        switch message.type {
+        case .session:
+            self = .session
+        case .directTCPIP(let message):
+            self = .directTCPIP(.init(targetHost: message.hostToConnectTo, targetPort: message.portToConnectTo, originatorAddress: message.originatorAddress))
+        case .forwardedTCPIP(let message):
+            self = .forwardedTCPIP(.init(listeningHost: message.hostListening, listeningPort: message.portListening, originatorAddress: message.originatorAddress))
+        }
+    }
+}
+
+extension SSHMessage.ChannelOpenMessage.ChannelType {
+    internal init(_ type: SSHChannelType) {
+        switch type {
+        case .session:
+            self = .session
+        case .directTCPIP(let data):
+            self = .directTCPIP(.init(hostToConnectTo: data.targetHost, portToConnectTo: data._targetPort, originatorAddress: data.originatorAddress))
+        case .forwardedTCPIP(let data):
+            self = .forwardedTCPIP(.init(hostListening: data.listeningHost, portListening: data._listeningPort, originatorAddress: data.originatorAddress))
+        }
+    }
+}

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsChannelMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsChannelMessages.swift
@@ -43,4 +43,8 @@ extension AcceptsChannelMessages {
     mutating func receiveChannelFailure(_: SSHMessage.ChannelFailureMessage) throws {}
 
     mutating func receiveGlobalRequest(_: SSHMessage.GlobalRequestMessage) throws {}
+
+    mutating func receiveRequestSuccess(_: SSHMessage.RequestSuccessMessage) throws {}
+
+    mutating func receiveRequestFailure() throws {}
 }

--- a/Sources/NIOSSH/Connection State Machine/Operations/SendsChannelMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/SendsChannelMessages.swift
@@ -63,4 +63,16 @@ extension SendsChannelMessages {
     mutating func writeChannelFailure(_ message: SSHMessage.ChannelFailureMessage, into buffer: inout ByteBuffer) throws {
         try self.serializer.serialize(message: .channelFailure(message), to: &buffer)
     }
+
+    mutating func writeGlobalRequest(_ message: SSHMessage.GlobalRequestMessage, into buffer: inout ByteBuffer) throws {
+        try self.serializer.serialize(message: .globalRequest(message), to: &buffer)
+    }
+
+    mutating func writeRequestSuccess(_ message: SSHMessage.RequestSuccessMessage, into buffer: inout ByteBuffer) throws {
+        try self.serializer.serialize(message: .requestSuccess(message), to: &buffer)
+    }
+
+    mutating func writeRequestFailure(into buffer: inout ByteBuffer) throws {
+        try self.serializer.serialize(message: .requestFailure, to: &buffer)
+    }
 }

--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -107,6 +107,10 @@ extension NIOSSHError {
     }
 
     internal static let unsupportedGlobalRequest = NIOSSHError(type: .unsupportedGlobalRequest, diagnostics: nil)
+
+    internal static let unexpectedGlobalRequestResponse = NIOSSHError(type: .unexpectedGlobalRequestResponse, diagnostics: nil)
+
+    internal static let globalRequestRefused = NIOSSHError(type: .globalRequestRefused, diagnostics: nil)
 }
 
 // MARK: - NIOSSHError CustomStringConvertible conformance.
@@ -146,6 +150,8 @@ extension NIOSSHError {
             case invalidUserAuthSignature
             case unknownPacketType
             case unsupportedGlobalRequest
+            case unexpectedGlobalRequestResponse
+            case globalRequestRefused
         }
 
         private var base: Base
@@ -222,6 +228,12 @@ extension NIOSSHError {
 
         /// A global request was made and rejected due to being unsupported.
         public static let unsupportedGlobalRequest: ErrorType = .init(.unsupportedGlobalRequest)
+
+        /// We received a response to a global request that we were not expecting.
+        public static let unexpectedGlobalRequestResponse: ErrorType = .init(.unexpectedGlobalRequestResponse)
+
+        /// A global request was refused by the peer.
+        public static let globalRequestRefused: ErrorType = .init(.globalRequestRefused)
     }
 }
 

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -50,13 +50,20 @@ public final class NIOSSHHandler {
 
     // A buffer of pending channel initializations. A channel initialization is pending if
     // we're attempting to initialize a channel before user auth is complete.
-    private var pendingChannelInitializations: CircularBuffer<(promise: EventLoopPromise<Channel>?, initializer: ((Channel) -> EventLoopFuture<Void>)?)>
+    private var pendingChannelInitializations: CircularBuffer<(promise: EventLoopPromise<Channel>?, channelType: SSHChannelType, initializer: SSHChildChannel.Initializer?)>
 
-    public init(role: SSHConnectionRole, allocator: ByteBufferAllocator, inboundChildChannelInitializer: ((Channel) -> EventLoopFuture<Void>)?) {
+    // A buffer of pending global requests. A global request is pending if we tried to send it before user auth completed.
+    private var pendingGlobalRequests: CircularBuffer<(SSHMessage.GlobalRequestMessage, EventLoopPromise<GlobalRequest.GlobalRequestResponse>?)>
+
+    private var pendingGlobalRequestResponses: CircularBuffer<EventLoopPromise<GlobalRequest.GlobalRequestResponse>?>
+
+    public init(role: SSHConnectionRole, allocator: ByteBufferAllocator, inboundChildChannelInitializer: ((Channel, SSHChannelType) -> EventLoopFuture<Void>)?) {
         self.stateMachine = SSHConnectionStateMachine(role: role)
         self.pendingWrite = false
         self.outboundFrameBuffer = allocator.buffer(capacity: 1024)
         self.pendingChannelInitializations = CircularBuffer(initialCapacity: 4)
+        self.pendingGlobalRequests = CircularBuffer(initialCapacity: 4)
+        self.pendingGlobalRequestResponses = CircularBuffer(initialCapacity: 4)
         self.multiplexer = SSHChannelMultiplexer(delegate: self, allocator: allocator, childChannelInitializer: inboundChildChannelInitializer)
     }
 }
@@ -78,6 +85,9 @@ extension NIOSSHHandler: ChannelDuplexHandler {
         // but we _can_, and it doesn't hurt.
         self.multiplexer?.parentHandlerRemoved()
         self.multiplexer = nil
+
+        self.dropAllPendingGlobalRequests(ChannelError.eof)
+        self.dropUnsatisfiedGlobalRequests(ChannelError.eof)
     }
 
     public func channelActive(context: ChannelHandlerContext) {
@@ -123,6 +133,7 @@ extension NIOSSHHandler: ChannelDuplexHandler {
         }
 
         self.createPendingChannelsIfPossible()
+        self.sendGlobalRequestsIfPossible()
     }
 
     private func writeMessage(_ multiMessage: SSHMultiMessage, context: ChannelHandlerContext, promise: EventLoopPromise<Void>? = nil) throws {
@@ -163,6 +174,10 @@ extension NIOSSHHandler: ChannelDuplexHandler {
             }
         case .forwardToMultiplexer(let message):
             try self.multiplexer?.receiveMessage(message)
+        case .globalRequest(let message):
+            try self.handleGlobalRequest(message)
+        case .globalRequestResponse(let response):
+            try self.handleGlobalRequestResponse(response)
         case .disconnect:
             // Welp, we immediately have to close.
             context.close(promise: nil)
@@ -173,25 +188,164 @@ extension NIOSSHHandler: ChannelDuplexHandler {
 // MARK: Create a child channel
 
 extension NIOSSHHandler {
-    public func createChannel(_ promise: EventLoopPromise<Channel>? = nil, _ channelInitializer: ((Channel) -> EventLoopFuture<Void>)?) {
-        self.pendingChannelInitializations.append((promise: promise, initializer: channelInitializer))
+    /// Creates an SSH channel.
+    ///
+    /// This function is **not** thread-safe: it may only be called from on the channel.
+    ///
+    /// - parameters:
+    ///     - promise: An `EventLoopPromise` that will be fulfilled with the channel when it becomes active.
+    ///     - channelType: The type of the channel to create. Defaults to `.session` for running remote processes.
+    ///     - channelInitializer: A callback that will be invoked to initialize the channel.
+    public func createChannel(_ promise: EventLoopPromise<Channel>? = nil, channelType: SSHChannelType = .session, _ channelInitializer: ((Channel, SSHChannelType) -> EventLoopFuture<Void>)?) {
+        self.pendingChannelInitializations.append((promise: promise, channelType: channelType, initializer: channelInitializer))
         self.createPendingChannelsIfPossible()
     }
 
     private func createPendingChannelsIfPossible() {
-        guard self.stateMachine.canInitializeChildChannels, self.pendingChannelInitializations.count > 0 else {
+        guard self.stateMachine.isActive, self.pendingChannelInitializations.count > 0 else {
             // No work to do
             return
         }
 
         if let multiplexer = self.multiplexer {
             while let next = self.pendingChannelInitializations.popFirst() {
-                multiplexer.createChildChannel(next.promise, next.initializer)
+                multiplexer.createChildChannel(next.promise, channelType: next.channelType, next.initializer)
             }
         } else {
             while let next = self.pendingChannelInitializations.popFirst() {
                 next.promise?.fail(NIOSSHError.creatingChannelAfterClosure)
             }
+        }
+    }
+}
+
+// MARK: Create a global request
+
+extension NIOSSHHandler {
+    /// Send a TCP forwarding request, either to initiate or cancel remote TCP forwarding.
+    ///
+    /// This function is **not** thread-safe: it may only be called from on the channel.
+    ///
+    /// - parameters:
+    ///     - request: The request to send.
+    ///     - promise: An `EventLoopPromise` that will be fulfilled when the request is accepted. Will error
+    ///         if the request was rejected or could not be sent.
+    public func sendTCPForwardingRequest(_ request: GlobalRequest.TCPForwardingRequest, promise: EventLoopPromise<GlobalRequest.GlobalRequestResponse>? = nil) {
+        let message = SSHMessage.GlobalRequestMessage(wantReply: true, type: .init(request))
+        self.pendingGlobalRequests.append((value: message, promise: promise))
+        self.sendGlobalRequestsIfPossible()
+    }
+
+    fileprivate func dropAllPendingGlobalRequests(_ error: Error) {
+        while let next = self.pendingGlobalRequests.popFirst() {
+            next.1?.fail(error)
+        }
+    }
+
+    fileprivate func dropUnsatisfiedGlobalRequests(_ error: Error) {
+        while let next = self.pendingGlobalRequestResponses.popFirst() {
+            next?.fail(error)
+        }
+    }
+
+    fileprivate func handleGlobalRequestResponse(_ response: SSHConnectionStateMachine.StateMachineInboundProcessResult.GlobalRequestResponse) throws {
+        guard let next = self.pendingGlobalRequestResponses.popFirst() else {
+            throw NIOSSHError.unexpectedGlobalRequestResponse
+        }
+
+        switch response {
+        case .success(let response):
+            next?.succeed(.init(response))
+        case .failure:
+            next?.fail(NIOSSHError.globalRequestRefused)
+        }
+    }
+
+    fileprivate func handleGlobalRequest(_ message: SSHMessage.GlobalRequestMessage) throws {
+        guard let context = context else {
+            // Weird, somehow we're out of the channel now. Drop this.
+            return
+        }
+
+        let responsePromise = context.eventLoop.makePromise(of: GlobalRequest.GlobalRequestResponse.self)
+        responsePromise.futureResult.whenComplete { result in
+            guard message.wantReply else {
+                // Nothing to do.
+                return
+            }
+
+            do {
+                switch result {
+                case .success(let response):
+                    try self.writeMessage(.init(.requestSuccess(.init(response))), context: context)
+                    context.flush()
+
+                case .failure:
+                    // We don't care why, we just say no.
+                    try self.writeMessage(.init(.requestFailure), context: context)
+                    context.flush()
+                }
+            } catch {
+                context.fireErrorCaught(error)
+            }
+        }
+
+        switch self.stateMachine.role {
+        case .client(let config):
+            config.globalRequestDelegate.tcpForwardingRequest(.init(message), handler: self, promise: responsePromise)
+        case .server(let config):
+            config.globalRequestDelegate.tcpForwardingRequest(.init(message), handler: self, promise: responsePromise)
+        }
+    }
+
+    private func sendGlobalRequestsIfPossible() {
+        guard let context = self.context else {
+            self.dropAllPendingGlobalRequests(ChannelError.ioOnClosedChannel)
+            return
+        }
+
+        guard self.stateMachine.isActive, self.pendingGlobalRequests.count > 0 else {
+            // No work to do
+            return
+        }
+
+        var didSend = false
+        while let next = self.pendingGlobalRequests.popFirst() {
+            didSend = true
+            self.sendGlobalRequest(next.0, promise: next.1, context: context)
+        }
+
+        if didSend {
+            context.flush()
+        }
+    }
+
+    private func sendGlobalRequest(_ request: SSHMessage.GlobalRequestMessage, promise: EventLoopPromise<GlobalRequest.GlobalRequestResponse>?, context: ChannelHandlerContext) {
+        // Sending a single global request is tricky, because we don't want to succeed the promise until we have the result of the
+        // request. That means we need a buffer of promises for request success/failure messages, as well as to create new promises.
+        let writePromise = context.eventLoop.makePromise(of: Void.self)
+        writePromise.futureResult.whenComplete { result in
+            switch result {
+            case .success:
+                guard self.context != nil else {
+                    // This write succeeded, but we're out of the pipeline anyway. Fail the promise.
+                    promise?.fail(ChannelError.eof)
+                    return
+                }
+
+                // Great, we're still active. Now we wait for a response.
+                // We add the nil promise here too to maintain ordering.
+                self.pendingGlobalRequestResponses.append(promise)
+
+            case .failure(let error):
+                promise?.fail(error)
+            }
+        }
+
+        do {
+            try self.writeMessage(.init(.globalRequest(request)), context: context, promise: writePromise)
+        } catch {
+            writePromise.fail(error)
         }
     }
 }

--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -114,4 +114,5 @@ final class ExampleExecHandler: ChannelDuplexHandler {
 enum SSHClientError: Swift.Error {
     case passwordAuthenticationNotSupported
     case commandExecFailed
+    case invalidChannelType
 }

--- a/Sources/NIOSSHServer/DataToBufferCodec.swift
+++ b/Sources/NIOSSHServer/DataToBufferCodec.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import NIO
+import NIOFoundationCompat
+import NIOSSH
+
+final class DataToBufferCodec: ChannelDuplexHandler {
+    typealias InboundIn = SSHChannelData
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = SSHChannelData
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        context.channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).whenFailure { error in
+            context.fireErrorCaught(error)
+        }
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+
+        guard case .byteBuffer(let bytes) = data.data else {
+            fatalError("Unexpected read type")
+        }
+
+        guard case .channel = data.type else {
+            context.fireErrorCaught(SSHServerError.invalidDataType)
+            return
+        }
+
+        context.fireChannelRead(self.wrapInboundOut(bytes))
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let data = self.unwrapOutboundIn(data)
+        context.write(self.wrapOutboundOut(SSHChannelData(type: .channel, data: .byteBuffer(data))), promise: promise)
+    }
+}
+
+func createOutboundConnection(targetHost: String, targetPort: Int, loop: EventLoop) -> EventLoopFuture<Channel> {
+    ClientBootstrap(group: loop).channelInitializer { channel in
+        channel.eventLoop.makeSucceededFuture(())
+    }.connect(host: targetHost, port: targetPort)
+}

--- a/Sources/NIOSSHServer/ExecHandler.swift
+++ b/Sources/NIOSSHServer/ExecHandler.swift
@@ -21,6 +21,9 @@ import NIOSSH
 enum SSHServerError: Error {
     case invalidCommand
     case invalidDataType
+    case invalidChannelType
+    case alreadyListening
+    case notListening
 }
 
 final class ExampleExecHandler: ChannelDuplexHandler {

--- a/Sources/NIOSSHServer/RemotePortForwarding.swift
+++ b/Sources/NIOSSHServer/RemotePortForwarding.swift
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+import NIO
+import NIOFoundationCompat
+import NIOSSH
+
+// Remote port forwarding is a fun feature of SSH where a client can ask an SSH server to listen on a local
+// port on its behalf. This file provides a some examples of how to configure this.
+// Please note that, as with the rest of this example, there are important security features missing from
+// this demo.
+final class RemotePortForwarder {
+    private var serverChannel: Channel?
+
+    private var inboundSSHHandler: NIOSSHHandler
+
+    init(inboundSSHHandler: NIOSSHHandler) {
+        self.inboundSSHHandler = inboundSSHHandler
+    }
+
+    func beginListening(on host: String, port: Int, loop: EventLoop) -> EventLoopFuture<Int?> {
+        ServerBootstrap(group: loop).serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SocketOptionName(SO_REUSEADDR)), value: 1)
+            .childChannelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            .childChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SocketOptionName(SO_REUSEADDR)), value: 1)
+            .childChannelInitializer { childChannel in
+                let (ours, theirs) = GlueHandler.matchedPair()
+
+                // Ok, ask for the remote channel to be created. This needs remote half closure turned on and to be
+                // set up for data I/O.
+                let promise = loop.makePromise(of: Channel.self)
+                self.inboundSSHHandler.createChannel(promise, channelType: .forwardedTCPIP(.init(listeningHost: host, listeningPort: childChannel.localAddress!.port!, originatorAddress: childChannel.remoteAddress!))) { sshChildChannel, _ in
+                    sshChildChannel.pipeline.addHandlers([DataToBufferCodec(), theirs]).flatMap {
+                        sshChildChannel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                    }
+                }
+
+                // Great, now we add the glue handler to the newly-accepted channel, and then we don't allow this channel to go
+                // active until the SSH channel has. Both should go active at once.
+                return childChannel.pipeline.addHandler(ours).flatMap { _ in promise.futureResult }.map { _ in () }
+            }
+            .bind(host: host, port: port).map { channel in
+                if port == 0 {
+                    return channel.localAddress!.port!
+                } else {
+                    return nil
+                }
+            }
+    }
+
+    func stopListening() {
+        self.serverChannel?.close(promise: nil)
+    }
+}
+
+final class RemotePortForwarderGlobalRequestDelegate: GlobalRequestDelegate {
+    // This example delegate only tolerates one bound port per connection, but this is an artificial limit.
+    private var forwarder: RemotePortForwarder?
+
+    func tcpForwardingRequest(_ request: GlobalRequest.TCPForwardingRequest, handler: NIOSSHHandler, promise: EventLoopPromise<GlobalRequest.GlobalRequestResponse>) {
+        switch request {
+        case .listen(host: let host, port: let port):
+            guard self.forwarder == nil else {
+                promise.fail(SSHServerError.alreadyListening)
+                return
+            }
+
+            let forwarder = RemotePortForwarder(inboundSSHHandler: handler)
+            forwarder.beginListening(on: host, port: port, loop: promise.futureResult.eventLoop).map {
+                GlobalRequest.GlobalRequestResponse(boundPort: $0)
+            }.cascade(to: promise)
+
+        case .cancel:
+            guard let forwarder = self.forwarder else {
+                promise.fail(SSHServerError.notListening)
+                return
+            }
+
+            self.forwarder = nil
+            forwarder.stopListening()
+        }
+    }
+
+    deinit {
+        self.forwarder?.stopListening()
+    }
+}


### PR DESCRIPTION
Motivation:

SSH provides for the valuable feature of remote and local TCP port
forwarding. This allows SSH clients and servers to arrange for TCP
connections to be tunnelled over the SSH connection, exposing machines
at either end of the SSH connection to each other over a secure link.
This allows a sort of "poor man's VPN" that can be established using the
existing SSH infrastructure, which is often sufficient to enable a wide
range of use cases. We should support it too.

Modifications:

Wide-ranging. Added the idea of an SSH channel type, added support for
exposing those in the channel initializer callbacks, plumbed through
support for global requests in the form of a global request delegate,
and many more. Substantially reworked a bunch of the API and internals,
basically.

Result:

Remote and local TCP port forwarding work swimmingly well.