### PR TITLE
Disconnected states must not imploy more work can be done

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -329,7 +329,7 @@ struct SSHConnectionStateMachine {
 
         case .receivedDisconnect, .sentDisconnect:
             // We do no further I/O in these states.
-            return .noMessage
+            return nil
         }
     }
 


### PR DESCRIPTION
Motivation:

In an earlier patch for disconnect messages I accidentally missed the
fact that `.noMessage` implies that more work can be done, and so is a
bad return type for the disconnected states.

Modifications:

Disconnected states should return `nil`.

Result:

No infinite loops when peers go away!