### PR TITLE
Fix infinite loop.

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -163,7 +163,7 @@ struct SSHConnectionStateMachine {
                 // > o  Specific key exchange method messages (30 to 49).
                 //
                 // We should enforce that, but right now we don't have a good mechanism by which to do so.
-                return .noMessage
+                throw NIOSSHError.protocolViolation(protocolName: "user auth", violation: "Unexpected user auth message: \(message)")
             }
         case .sentNewKeys(var state):
             guard let message = try state.parser.nextPacket() else {
@@ -215,7 +215,7 @@ struct SSHConnectionStateMachine {
                 // > o  Specific key exchange method messages (30 to 49).
                 //
                 // We should enforce that, but right now we don't have a good mechanism by which to do so.
-                return .noMessage
+                throw NIOSSHError.protocolViolation(protocolName: "key exchange", violation: "Unexpected message: \(message)")
             }
 
         case .receivedNewKeys(var state):

--- a/Tests/NIOSSHTests/FuzzResultTests.swift
+++ b/Tests/NIOSSHTests/FuzzResultTests.swift
@@ -59,4 +59,8 @@ final class FuzzResultTests: XCTestCase {
     func testOne() {
         self.runTest(base64EncodedTestData: "AAoKDQ==")
     }
+
+    func testTwo() {
+        self.runTest(base64EncodedTestData: "U1NILTIuMAAAsA0KAAAADQtR+ABpY3VkdDY1ACA=")
+    }
 }


### PR DESCRIPTION
Motivation:

Unexpected messages in the key exchange phase could lead to infinite
loops because we'd ignore them, but not mark them as processed. For now,
as we handle a wider range of messages, we'll just consider unexpected
messages errors.

Modifications:

- Replaced .noMessage with throwing in two cases.

Result:

No remote triggerable infinite loop.