### PR TITLE
Add a sanity check to see if swiftformat is available

### DIFF
--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -21,6 +21,8 @@ function replace_acceptable_years() {
     sed -e 's/2017-201[89]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/'
 }
 
+command -v swiftformat >/dev/null 2>&1 || { echo >&2 "swiftformat needs to be installed but is not available in the path."; exit 1; }
+
 printf "=> Checking format... "
 FIRST_OUT="$(git status --porcelain)"
 swiftformat . > /dev/null 2>&1


### PR DESCRIPTION
Motivation:
Not having swiftformat available within the script leads to a confusing exit without printing an error.

Modifications:
Check if swiftformat is available, and print an error if swiftformat is not available.

Result:
Not having swiftformat installed will notify you of this. Having swiftformat installed functions the same.