### PR TITLE
Prefer AES-256 to AES-128.

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -61,7 +61,7 @@ struct SSHConnectionStateMachine {
     private var state: State
 
     private static let defaultTransportProtectionSchemes: [NIOSSHTransportProtection.Type] = [
-        AES128GCMOpenSSHTransportProtection.self, AES256GCMOpenSSHTransportProtection.self,
+        AES256GCMOpenSSHTransportProtection.self, AES128GCMOpenSSHTransportProtection.self,
     ]
 
     init(role: SSHConnectionRole, protectionSchemes: [NIOSSHTransportProtection.Type] = Self.defaultTransportProtectionSchemes) {


### PR DESCRIPTION
Motivation:

The industry has been moving towards preferring larger key sizes in AES.
We should reflect that.

Modifications:

- Prefer AES-256 to AES-128.

Result:

More connections with larger key sizes.