### PR TITLE
Correctly handle host key negotiation.

### DIFF
--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -118,6 +118,11 @@ extension NIOSSHError {
     internal static func remotePeerDoesNotSupportMessage(_ message: SSHMessage.UnimplementedMessage) -> NIOSSHError {
         NIOSSHError(type: .remotePeerDoesNotSupportMessage, diagnostics: "Sequence Number: \(message.sequenceNumber)")
     }
+
+    @inline(never)
+    internal static func invalidHostKeyForKeyExchange(expected: Substring, got actual: String.UTF8View) -> NIOSSHError {
+        NIOSSHError(type: .invalidHostKeyForKeyExchange, diagnostics: "Expected \(String(expected)), got \(String(actual))")
+    }
 }
 
 // MARK: - NIOSSHError CustomStringConvertible conformance.
@@ -161,6 +166,7 @@ extension NIOSSHError {
             case globalRequestRefused
             case missingGlobalRequestResponse
             case remotePeerDoesNotSupportMessage
+            case invalidHostKeyForKeyExchange
         }
 
         private var base: Base
@@ -249,6 +255,9 @@ extension NIOSSHError {
 
         /// The remote peer sent an "unimplemented" message, indicating they do not support a message we sent.
         public static let remotePeerDoesNotSupportMessage: ErrorType = .init(.remotePeerDoesNotSupportMessage)
+
+        /// The peer has sent a host key that does not correspond to the one negotiated in key exchange.
+        public static let invalidHostKeyForKeyExchange: ErrorType = .init(.invalidHostKeyForKeyExchange)
     }
 }
 


### PR DESCRIPTION
Motivation:

We took a shortcut in our code for negotiating which host key algorithm
to use, which is that we preferred the first one in our list that was
also in the peer's. This is obviously not right: the preference is
supposed to be the first one in the client's that's also in the
server's. We just happened to be unlucky enough to get away with this
for now.

While I was investigating this I also spotted that we never actually
validated that the server respected the negotiation result, so that code
had to be added too.

Modifications:

- Updated the negotiation code to validate that the server sends back a
  key of the right type.
- Updated the negotiation code to ensure that we negotiate host keys per
  the spec.

Result:

We negotiate host keys the way we're supposed to.