### PR TITLE
Add support for P384 and P521.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SwiftNIO SSH supports SSHv2 with the following feature set:
 
 - All session channel features, including shell and exec channel requests
 - Direct and reverse TCP port forwarding
-- Modern cryptographic primitives only: Ed25519 and EDCSA over P256 for asymmetric cryptography, AES-GCM for symmetric cryptography, x25519 for key exchange
+- Modern cryptographic primitives only: Ed25519 and EDCSA over the major NIST curves (P256, P384, P521) for asymmetric cryptography, AES-GCM for symmetric cryptography, x25519 for key exchange
 - Password and public key user authentication
 - Supports all platforms supported by SwiftNIO and Swift Crypto
 

--- a/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
+++ b/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
@@ -475,7 +475,7 @@ extension SSHKeyExchangeStateMachine {
     static let supportedKeyExchangeAlgorithms: [Substring] = ["curve25519-sha256", "curve25519-sha256@libssh.org"]
 
     /// All known host key algorithms.
-    static let supportedServerHostKeyAlgorithms: [Substring] = ["ssh-ed25519", "ecdsa-sha2-nistp256"]
+    static let supportedServerHostKeyAlgorithms: [Substring] = ["ssh-ed25519", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp521"]
 }
 
 extension SSHKeyExchangeStateMachine {

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -38,6 +38,14 @@ public struct NIOSSHPrivateKey {
         self.backingKey = .ecdsaP256(key)
     }
 
+    public init(p384Key key: P384.Signing.PrivateKey) {
+        self.backingKey = .ecdsaP384(key)
+    }
+
+    public init(p521Key key: P521.Signing.PrivateKey) {
+        self.backingKey = .ecdsaP521(key)
+    }
+
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     public init(secureEnclaveP256Key key: SecureEnclave.P256.Signing.PrivateKey) {
         self.backingKey = .secureEnclaveP256(key)
@@ -51,6 +59,10 @@ public struct NIOSSHPrivateKey {
             return ["ssh-ed25519"]
         case .ecdsaP256:
             return ["ecdsa-sha2-nistp256"]
+        case .ecdsaP384:
+            return ["ecdsa-sha2-nistp384"]
+        case .ecdsaP521:
+            return ["ecdsa-sha2-nistp521"]
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256:
             return ["ecdsa-sha2-nistp256"]
@@ -64,6 +76,8 @@ extension NIOSSHPrivateKey {
     internal enum BackingKey {
         case ed25519(Curve25519.Signing.PrivateKey)
         case ecdsaP256(P256.Signing.PrivateKey)
+        case ecdsaP384(P384.Signing.PrivateKey)
+        case ecdsaP521(P521.Signing.PrivateKey)
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
@@ -84,6 +98,16 @@ extension NIOSSHPrivateKey {
                 try key.signature(for: ptr)
             }
             return SSHSignature(backingSignature: .ecdsaP256(signature))
+        case .ecdsaP384(let key):
+            let signature = try digest.withUnsafeBytes { ptr in
+                try key.signature(for: ptr)
+            }
+            return SSHSignature(backingSignature: .ecdsaP384(signature))
+        case .ecdsaP521(let key):
+            let signature = try digest.withUnsafeBytes { ptr in
+                try key.signature(for: ptr)
+            }
+            return SSHSignature(backingSignature: .ecdsaP521(signature))
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
@@ -103,6 +127,12 @@ extension NIOSSHPrivateKey {
         case .ecdsaP256(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return SSHSignature(backingSignature: .ecdsaP256(signature))
+        case .ecdsaP384(let key):
+            let signature = try key.signature(for: payload.bytes.readableBytesView)
+            return SSHSignature(backingSignature: .ecdsaP384(signature))
+        case .ecdsaP521(let key):
+            let signature = try key.signature(for: payload.bytes.readableBytesView)
+            return SSHSignature(backingSignature: .ecdsaP521(signature))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
@@ -120,6 +150,10 @@ extension NIOSSHPrivateKey {
             return NIOSSHPublicKey(backingKey: .ed25519(privateKey.publicKey))
         case .ecdsaP256(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP256(privateKey.publicKey))
+        case .ecdsaP384(let privateKey):
+            return NIOSSHPublicKey(backingKey: .ecdsaP384(privateKey.publicKey))
+        case .ecdsaP521(let privateKey):
+            return NIOSSHPublicKey(backingKey: .ecdsaP521(privateKey.publicKey))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP256(privateKey.publicKey))

--- a/Tests/NIOSSHTests/ByteBuffer+SSHTests.swift
+++ b/Tests/NIOSSHTests/ByteBuffer+SSHTests.swift
@@ -252,6 +252,44 @@ final class ByteBufferSSHTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertNotNil(try buffer.readSSHSignature()))
     }
 
+    func testReadingECDSAP384SignaturesFromBuffers() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p384Key: .init())
+        let signature = try assertNoThrowWithValue(key.sign(digest: SHA384.hash(data: Array("hello, world!".utf8))))
+
+        // Write a signature in.
+        buffer.writeSSHSignature(signature)
+
+        // Try reading short. This should always return nil, and never move the indices.
+        for sliceLength in 0 ..< buffer.readableBytes {
+            var slice = buffer.getSlice(at: buffer.readerIndex, length: sliceLength)!
+            XCTAssertNoThrow(XCTAssertNil(try slice.readSSHSignature()))
+            XCTAssertEqual(slice.readerIndex, 0)
+            XCTAssertEqual(slice.writerIndex, sliceLength)
+        }
+
+        XCTAssertNoThrow(XCTAssertNotNil(try buffer.readSSHSignature()))
+    }
+
+    func testReadingECDSAP521SignaturesFromBuffers() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p521Key: .init())
+        let signature = try assertNoThrowWithValue(key.sign(digest: SHA512.hash(data: Array("hello, world!".utf8))))
+
+        // Write a signature in.
+        buffer.writeSSHSignature(signature)
+
+        // Try reading short. This should always return nil, and never move the indices.
+        for sliceLength in 0 ..< buffer.readableBytes {
+            var slice = buffer.getSlice(at: buffer.readerIndex, length: sliceLength)!
+            XCTAssertNoThrow(XCTAssertNil(try slice.readSSHSignature()))
+            XCTAssertEqual(slice.readerIndex, 0)
+            XCTAssertEqual(slice.writerIndex, sliceLength)
+        }
+
+        XCTAssertNoThrow(XCTAssertNotNil(try buffer.readSSHSignature()))
+    }
+
     func testReadingEd25519PublicKeysFromBuffers() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         let key = NIOSSHPrivateKey(ed25519Key: .init())
@@ -273,6 +311,42 @@ final class ByteBufferSSHTests: XCTestCase {
     func testReadingECDASAP256PublicKeysFromBuffers() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         let key = NIOSSHPrivateKey(p256Key: .init())
+
+        // Write a signature in.
+        buffer.writeSSHHostKey(key.publicKey)
+
+        // Try reading short. This should always return nil, and never move the indices.
+        for sliceLength in 0 ..< buffer.readableBytes {
+            var slice = buffer.getSlice(at: buffer.readerIndex, length: sliceLength)!
+            XCTAssertNoThrow(XCTAssertNil(try slice.readSSHHostKey()))
+            XCTAssertEqual(slice.readerIndex, 0)
+            XCTAssertEqual(slice.writerIndex, sliceLength)
+        }
+
+        XCTAssertNoThrow(XCTAssertNotNil(try buffer.readSSHHostKey()))
+    }
+
+    func testReadingECDASAP384PublicKeysFromBuffers() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p384Key: .init())
+
+        // Write a signature in.
+        buffer.writeSSHHostKey(key.publicKey)
+
+        // Try reading short. This should always return nil, and never move the indices.
+        for sliceLength in 0 ..< buffer.readableBytes {
+            var slice = buffer.getSlice(at: buffer.readerIndex, length: sliceLength)!
+            XCTAssertNoThrow(XCTAssertNil(try slice.readSSHHostKey()))
+            XCTAssertEqual(slice.readerIndex, 0)
+            XCTAssertEqual(slice.writerIndex, sliceLength)
+        }
+
+        XCTAssertNoThrow(XCTAssertNotNil(try buffer.readSSHHostKey()))
+    }
+
+    func testReadingECDASAP521PublicKeysFromBuffers() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p521Key: .init())
 
         // Write a signature in.
         buffer.writeSSHHostKey(key.publicKey)

--- a/Tests/NIOSSHTests/Curve25519KeyExchangeTests.swift
+++ b/Tests/NIOSSHTests/Curve25519KeyExchangeTests.swift
@@ -100,10 +100,68 @@ final class Curve25519KeyExchangeTests: XCTestCase {
         self.keyExchangeAgreed(serverKeys, clientKeys)
     }
 
-    func testKeyExchangeWithECDSASignatures() throws {
+    func testKeyExchangeWithECDSAP256Signatures() throws {
         var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
         var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(p256Key: .init())
+
+        var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
+
+        let clientMessage = client.initiateKeyExchangeClientSide(allocator: ByteBufferAllocator())
+        let (serverKeys, serverResponse) = try assertNoThrowWithValue(
+            try server.completeKeyExchangeServerSide(clientKeyExchangeMessage: clientMessage,
+                                                     serverHostKey: serverHostKey,
+                                                     initialExchangeBytes: &initialExchangeBytes,
+                                                     allocator: ByteBufferAllocator(),
+                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+        )
+
+        initialExchangeBytes.clear()
+
+        let clientKeys = try assertNoThrowWithValue(
+            try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
+                                                       initialExchangeBytes: &initialExchangeBytes,
+                                                       allocator: ByteBufferAllocator(),
+                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+        )
+
+        // Check we agree on the session ID and the keys.
+        self.keyExchangeAgreed(serverKeys, clientKeys)
+    }
+
+    func testKeyExchangeWithECDSAP384Signatures() throws {
+        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        let serverHostKey = NIOSSHPrivateKey(p384Key: .init())
+
+        var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
+
+        let clientMessage = client.initiateKeyExchangeClientSide(allocator: ByteBufferAllocator())
+        let (serverKeys, serverResponse) = try assertNoThrowWithValue(
+            try server.completeKeyExchangeServerSide(clientKeyExchangeMessage: clientMessage,
+                                                     serverHostKey: serverHostKey,
+                                                     initialExchangeBytes: &initialExchangeBytes,
+                                                     allocator: ByteBufferAllocator(),
+                                                     expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+        )
+
+        initialExchangeBytes.clear()
+
+        let clientKeys = try assertNoThrowWithValue(
+            try client.receiveServerKeyExchangePayload(serverKeyExchangeMessage: serverResponse,
+                                                       initialExchangeBytes: &initialExchangeBytes,
+                                                       allocator: ByteBufferAllocator(),
+                                                       expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes)
+        )
+
+        // Check we agree on the session ID and the keys.
+        self.keyExchangeAgreed(serverKeys, clientKeys)
+    }
+
+    func testKeyExchangeWithECDSAP521Signatures() throws {
+        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        let serverHostKey = NIOSSHPrivateKey(p521Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
 

--- a/Tests/NIOSSHTests/HostKeyTests.swift
+++ b/Tests/NIOSSHTests/HostKeyTests.swift
@@ -54,6 +54,42 @@ final class HostKeyTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertTrue(sshKey.publicKey.isValidSignature(newSignature, for: digest)))
     }
 
+    func testBasicECDSAP384SigningFlow() throws {
+        let ecdsaKey = P384.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p384Key: ecdsaKey)
+
+        let digest = SHA384.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        // Naturally, this should verify.
+        XCTAssertNoThrow(XCTAssertTrue(sshKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertTrue(sshKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
+    func testBasicECDSAP521SigningFlow() throws {
+        let ecdsaKey = P521.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p521Key: ecdsaKey)
+
+        let digest = SHA512.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        // Naturally, this should verify.
+        XCTAssertNoThrow(XCTAssertTrue(sshKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertTrue(sshKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
     func testEd25519FailsVerificationWithDifferentKeys() throws {
         let edKey = Curve25519.Signing.PrivateKey()
         let sshKey = NIOSSHPrivateKey(ed25519Key: edKey)
@@ -82,6 +118,46 @@ final class HostKeyTests: XCTestCase {
         let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
 
         let otherSSHKey = NIOSSHPrivateKey(p256Key: .init())
+
+        // Naturally, this should not verify.
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
+    func testECDASP384FailsVerificationWithDifferentKeys() throws {
+        let ecdsaKey = P384.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p384Key: ecdsaKey)
+
+        let digest = SHA384.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        let otherSSHKey = NIOSSHPrivateKey(p384Key: .init())
+
+        // Naturally, this should not verify.
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
+    func testECDASP521FailsVerificationWithDifferentKeys() throws {
+        let ecdsaKey = P521.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p521Key: ecdsaKey)
+
+        let digest = SHA512.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        let otherSSHKey = NIOSSHPrivateKey(p521Key: .init())
 
         // Naturally, this should not verify.
         XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(signature, for: digest)))
@@ -134,6 +210,46 @@ final class HostKeyTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(newSignature, for: digest)))
     }
 
+    func testECDASP384FailsVerificationWithWrongAlgorithms() throws {
+        let ecdsaKey = P384.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p384Key: ecdsaKey)
+
+        let digest = SHA384.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        let otherSSHKey = NIOSSHPrivateKey(ed25519Key: .init())
+
+        // Naturally, this should not verify.
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
+    func testECDASP521FailsVerificationWithWrongAlgorithms() throws {
+        let ecdsaKey = P521.Signing.PrivateKey()
+        let sshKey = NIOSSHPrivateKey(p521Key: ecdsaKey)
+
+        let digest = SHA512.hash(data: Array("hello, world!".utf8))
+        let signature = try assertNoThrowWithValue(sshKey.sign(digest: digest))
+
+        let otherSSHKey = NIOSSHPrivateKey(ed25519Key: .init())
+
+        // Naturally, this should not verify.
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(signature, for: digest)))
+
+        // Now let's try round-tripping through bytebuffer.
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHSignature(signature)
+
+        let newSignature = try assertNoThrowWithValue(buffer.readSSHSignature()!)
+        XCTAssertNoThrow(XCTAssertFalse(otherSSHKey.publicKey.isValidSignature(newSignature, for: digest)))
+    }
+
     func testUnrecognisedKey() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeSSHString("ssh-rsa".utf8)
@@ -146,6 +262,26 @@ final class HostKeyTests: XCTestCase {
     func testInvalidDomainParametersForECDSAP256() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeSSHString("ecdsa-sha2-nistp256".utf8)
+        buffer.writeSSHString("nistp384".utf8) // Surprise!
+
+        XCTAssertThrowsError(try buffer.readSSHHostKey()) { error in
+            XCTAssertEqual((error as? NIOSSHError).map { $0.type }, .invalidDomainParametersForKey)
+        }
+    }
+
+    func testInvalidDomainParametersForECDSAP384() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHString("ecdsa-sha2-nistp384".utf8)
+        buffer.writeSSHString("nistp256".utf8) // Surprise!
+
+        XCTAssertThrowsError(try buffer.readSSHHostKey()) { error in
+            XCTAssertEqual((error as? NIOSSHError).map { $0.type }, .invalidDomainParametersForKey)
+        }
+    }
+
+    func testInvalidDomainParametersForECDSAP521() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        buffer.writeSSHString("ecdsa-sha2-nistp521".utf8)
         buffer.writeSSHString("nistp384".utf8) // Surprise!
 
         XCTAssertThrowsError(try buffer.readSSHHostKey()) { error in

--- a/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
@@ -406,6 +406,18 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
     }
 
     func testKeyExchangeUsingP256HostKeysOnly() throws {
+        try self.straightforwardCustomHostKeyHandshake(hostKey: .init(p256Key: .init()))
+    }
+
+    func testKeyExchangeUsingP384HostKeysOnly() throws {
+        try self.straightforwardCustomHostKeyHandshake(hostKey: .init(p384Key: .init()))
+    }
+
+    func testKeyExchangeUsingP521HostKeysOnly() throws {
+        try self.straightforwardCustomHostKeyHandshake(hostKey: .init(p521Key: .init()))
+    }
+
+    private func straightforwardCustomHostKeyHandshake(hostKey: NIOSSHPrivateKey) throws {
         // This test runs a full key exchange but the server races its newKeys message right behind the ecdh reply.
         let allocator = ByteBufferAllocator()
 
@@ -418,7 +430,7 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
         )
         var server = SSHKeyExchangeStateMachine(
             allocator: allocator,
-            role: .server(.init(hostKeys: [.init(p256Key: .init())], userAuthDelegate: DenyAllServerAuthDelegate())),
+            role: .server(.init(hostKeys: [hostKey], userAuthDelegate: DenyAllServerAuthDelegate())),
             remoteVersion: Constants.version,
             protectionSchemes: [AES256GCMOpenSSHTransportProtection.self],
             previousSessionIdentifier: nil

--- a/Tests/NIOSSHTests/SSHMessagesTests.swift
+++ b/Tests/NIOSSHTests/SSHMessagesTests.swift
@@ -296,9 +296,31 @@ final class SSHMessagesTests: XCTestCase {
         XCTAssertEqual(try buffer.readSSHMessage(), expectedMessage)
     }
 
-    func testUserAuthPKOK() throws {
+    func testUserAuthPKOKP256() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         let key = NIOSSHPrivateKey(p256Key: .init())
+        let message = SSHMessage.userAuthPKOK(.init(key: key.publicKey))
+
+        buffer.writeSSHMessage(message)
+        XCTAssertEqual(try buffer.readSSHMessage(), message)
+
+        try self.assertCorrectlyManagesPartialRead(message)
+    }
+
+    func testUserAuthPKOKP384() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p384Key: .init())
+        let message = SSHMessage.userAuthPKOK(.init(key: key.publicKey))
+
+        buffer.writeSSHMessage(message)
+        XCTAssertEqual(try buffer.readSSHMessage(), message)
+
+        try self.assertCorrectlyManagesPartialRead(message)
+    }
+
+    func testUserAuthPKOKP521() throws {
+        var buffer = ByteBufferAllocator().buffer(capacity: 1024)
+        let key = NIOSSHPrivateKey(p521Key: .init())
         let message = SSHMessage.userAuthPKOK(.init(key: key.publicKey))
 
         buffer.writeSSHMessage(message)

--- a/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
@@ -638,7 +638,19 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         }
     }
 
-    func testPrivateKeyServerAuthFlow() throws {
+    func testPrivateKeyServerAuthFlowP256() throws {
+        try self.privateKeyServerAuthFlow(.init(p256Key: .init()))
+    }
+
+    func testPrivateKeyServerAuthFlowP384() throws {
+        try self.privateKeyServerAuthFlow(.init(p384Key: .init()))
+    }
+
+    func testPrivateKeyServerAuthFlowP521() throws {
+        try self.privateKeyServerAuthFlow(.init(p521Key: .init()))
+    }
+
+    func privateKeyServerAuthFlow(_ newKey: NIOSSHPrivateKey) throws {
         var stateMachine = UserAuthenticationStateMachine(role: .server(.init(hostKeys: [self.hostKey], userAuthDelegate: DenyThenAcceptDelegate(messagesToDeny: 1))), loop: self.loop, sessionID: self.sessionID)
 
         // Begin by doing the service accept dance.
@@ -663,7 +675,6 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
         // Ok, let's do another query with a different key type. This time we won't bother with the little preamble dance, we'll just go straight to
         // querying: this should be fine too.
-        let newKey = NIOSSHPrivateKey(p256Key: .init())
         let payload2 = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: newKey.publicKey)
         let newSignature = try newKey.sign(payload2)
         let request2 = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: newKey.publicKey, signature: newSignature)))


### PR DESCRIPTION
Motivation:

The larger NIST curves can provide advantages in terms of the effective
security they provide. This comes with trade-offs: in particular,
computation over these curves is slower. However, right now we only
provide curves with ~128-bit security. The two larger curves would be
good to support too.

Modifications:

- Add key support with P384 and P521.

Result:

Users can have P384/P521 keys, and so can hosts.