### PR TITLE
Extend key exchange to NIST curves as well.

### DIFF
--- a/Sources/NIOSSH/Key Exchange/ECDHCompatibleKey.swift
+++ b/Sources/NIOSSH/Key Exchange/ECDHCompatibleKey.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIO
+import NIOFoundationCompat
+
+/// This protocol represents a public key that is capable of performing an ECDH key exchange in SSH.
+///
+/// We use this protocol to abstract the various portions of the ECDH key exchange that are key-specific
+/// while keeping common the various protocol elements that don't vary.
+protocol ECDHCompatiblePublicKey {
+    /// Construct a copy of this key from a `ByteBuffer`.
+    init(buffer: ByteBuffer) throws
+
+    /// Write a copy of the public key bytes to a `ByteBuffer`
+    @discardableResult
+    func write(to: inout ByteBuffer) -> Int
+}
+
+/// This protocol represents a private key that is capable of performing an ECDH key exchange in SSH.
+///
+/// We use this protocol to abstract the various portions of the ECDH key exchange that are key-specific
+/// while keeping common the various protocol elements that don't vary.
+protocol ECDHCompatiblePrivateKey {
+    associatedtype PublicKey: ECDHCompatiblePublicKey
+
+    associatedtype Hasher: HashFunction
+
+    init()
+
+    var publicKey: PublicKey { get }
+
+    func generatedSharedSecret(with: PublicKey) throws -> SharedSecret
+
+    static var keyExchangeAlgorithmNames: [Substring] { get }
+}
+
+// MARK: Conformances
+
+extension Curve25519.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
+    init(buffer keyBytes: ByteBuffer) throws {
+        // Curve25519 keys are essentially unstructured bags of bytes. It's great.
+        self = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: keyBytes.readableBytesView)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        // Curve25519 keys are essentially unstructured bags of bytes. It's great.
+        buffer.writeBytes(self.rawRepresentation)
+    }
+}
+
+extension Curve25519.KeyAgreement.PrivateKey: ECDHCompatiblePrivateKey {
+    typealias Hasher = SHA256
+
+    func generatedSharedSecret(with other: Curve25519.KeyAgreement.PublicKey) throws -> SharedSecret {
+        let sharedSecret = try self.sharedSecretFromKeyAgreement(with: other)
+        guard sharedSecret.isStrongSecret else {
+            throw NIOSSHError.weakSharedSecret(exchangeAlgorithm: "Curve25519")
+        }
+        return sharedSecret
+    }
+
+    static let keyExchangeAlgorithmNames: [Substring] = ["curve25519-sha256", "curve25519-sha256@libssh.org"]
+}
+
+extension P256.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
+    init(buffer keyBytes: ByteBuffer) throws {
+        self = try P256.KeyAgreement.PublicKey(x963Representation: keyBytes.readableBytesView)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeBytes(self.x963Representation)
+    }
+}
+
+extension P256.KeyAgreement.PrivateKey: ECDHCompatiblePrivateKey {
+    init() {
+        self = .init(compactRepresentable: false)
+    }
+
+    typealias Hasher = SHA256
+
+    func generatedSharedSecret(with other: P256.KeyAgreement.PublicKey) throws -> SharedSecret {
+        try self.sharedSecretFromKeyAgreement(with: other)
+    }
+
+    static let keyExchangeAlgorithmNames: [Substring] = ["ecdh-sha2-nistp256"]
+}
+
+extension P384.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
+    init(buffer keyBytes: ByteBuffer) throws {
+        self = try P384.KeyAgreement.PublicKey(x963Representation: keyBytes.readableBytesView)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeBytes(self.x963Representation)
+    }
+}
+
+extension P384.KeyAgreement.PrivateKey: ECDHCompatiblePrivateKey {
+    init() {
+        self = .init(compactRepresentable: false)
+    }
+
+    typealias Hasher = SHA384
+
+    func generatedSharedSecret(with other: P384.KeyAgreement.PublicKey) throws -> SharedSecret {
+        try self.sharedSecretFromKeyAgreement(with: other)
+    }
+
+    static let keyExchangeAlgorithmNames: [Substring] = ["ecdh-sha2-nistp384"]
+}
+
+extension P521.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
+    init(buffer keyBytes: ByteBuffer) throws {
+        self = try P521.KeyAgreement.PublicKey(x963Representation: keyBytes.readableBytesView)
+    }
+
+    @discardableResult
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeBytes(self.x963Representation)
+    }
+}
+
+extension P521.KeyAgreement.PrivateKey: ECDHCompatiblePrivateKey {
+    init() {
+        self = .init(compactRepresentable: false)
+    }
+
+    typealias Hasher = SHA512
+
+    func generatedSharedSecret(with other: P521.KeyAgreement.PublicKey) throws -> SharedSecret {
+        try self.sharedSecretFromKeyAgreement(with: other)
+    }
+
+    static let keyExchangeAlgorithmNames: [Substring] = ["ecdh-sha2-nistp521"]
+}
+
+// MARK: Helpers
+
+extension SharedSecret {
+    /// In Curve25519 we need to check for the possibility that the peer's key is a point of low order.
+    /// If it is, we will end up generating the all-zero shared secret, which is pretty not good.
+    /// This property is `true` if the secret is strong, and `false` if it is not.
+    fileprivate var isStrongSecret: Bool {
+        // CryptoKit doesn't want to let us look directly at this, so we need to exfiltrate a pointer.
+        // For the sake of avoiding leaking information about the secret, we choose to do this in constant
+        // time by ORing every byte together: if the result is zero, this point is invalid.
+        self.withUnsafeBytes { dataPtr in
+            let allORed = dataPtr.reduce(UInt8(0)) { $0 | $1 }
+            return allORed != 0
+        }
+    }
+}

--- a/Tests/NIOSSHTests/ECKeyExchangeTests.swift
+++ b/Tests/NIOSSHTests/ECKeyExchangeTests.swift
@@ -17,7 +17,7 @@ import NIO
 @testable import NIOSSH
 import XCTest
 
-final class Curve25519KeyExchangeTests: XCTestCase {
+final class KeyExchangeTests: XCTestCase {
     private func keyExchangeAgreed(_ first: KeyExchangeResult, _ second: KeyExchangeResult) {
         XCTAssertEqual(first.sessionID, second.sessionID)
         XCTAssertEqual(first.keys.initialInboundIV, second.keys.initialOutboundIV)
@@ -39,9 +39,25 @@ final class Curve25519KeyExchangeTests: XCTestCase {
         XCTAssertNotEqual(first.keys.outboundMACKey, second.keys.inboundMACKey)
     }
 
-    func testBasicSuccessfulKeyExchangeNoPreviousSession() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+    func testBasicSuccessfulKeyExchangeNoPreviousSessionCurve25519() throws {
+        try self.basicSuccessfulKeyExchangeNoPreviousSession(Curve25519.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeNoPreviousSessionP256() throws {
+        try self.basicSuccessfulKeyExchangeNoPreviousSession(P256.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeNoPreviousSessionP384() throws {
+        try self.basicSuccessfulKeyExchangeNoPreviousSession(P384.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeNoPreviousSessionP521() throws {
+        try self.basicSuccessfulKeyExchangeNoPreviousSession(P521.KeyAgreement.PrivateKey.self)
+    }
+
+    private func basicSuccessfulKeyExchangeNoPreviousSession<KeyType: ECDHCompatiblePrivateKey>(_: KeyType.Type = KeyType.self) throws {
+        var server = EllipticCurveKeyExchange<KeyType>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<KeyType>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -68,12 +84,28 @@ final class Curve25519KeyExchangeTests: XCTestCase {
         self.keyExchangeAgreed(serverKeys, clientKeys)
     }
 
-    func testBasicSuccessfulKeyExchangeWithPreviousSession() throws {
+    func testBasicSuccessfulKeyExchangeWithPreviousSessionCurve25519() throws {
+        try self.basicSuccessfulKeyExchangeWithPreviousSession(Curve25519.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeWithPreviousSessionP256() throws {
+        try self.basicSuccessfulKeyExchangeWithPreviousSession(P256.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeWithPreviousSessionP384() throws {
+        try self.basicSuccessfulKeyExchangeWithPreviousSession(P384.KeyAgreement.PrivateKey.self)
+    }
+
+    func testBasicSuccessfulKeyExchangeWithPreviousSessionP521() throws {
+        try self.basicSuccessfulKeyExchangeWithPreviousSession(P521.KeyAgreement.PrivateKey.self)
+    }
+
+    func basicSuccessfulKeyExchangeWithPreviousSession<KeyType: ECDHCompatiblePrivateKey>(_: KeyType.Type = KeyType.self) throws {
         var previousSessionIdentifier = ByteBufferAllocator().buffer(capacity: 1024)
         previousSessionIdentifier.writeBytes(0 ... 255)
 
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: previousSessionIdentifier)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: previousSessionIdentifier)
+        var server = EllipticCurveKeyExchange<KeyType>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: previousSessionIdentifier)
+        var client = EllipticCurveKeyExchange<KeyType>(ourRole: .client, previousSessionIdentifier: previousSessionIdentifier)
         let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -101,8 +133,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testKeyExchangeWithECDSAP256Signatures() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(p256Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -130,8 +162,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testKeyExchangeWithECDSAP384Signatures() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(p384Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -159,8 +191,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testKeyExchangeWithECDSAP521Signatures() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(p521Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -188,8 +220,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testBasicSuccessfulKeyExchangeWithWiderKeys() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -217,8 +249,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testDisagreeingOnInitialExchangeBytesLeadsToFailedKeyExchange() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
 
         var serverInitialBytes = ByteBufferAllocator().buffer(capacity: 1024)
@@ -247,8 +279,8 @@ final class Curve25519KeyExchangeTests: XCTestCase {
     }
 
     func testWeValidateTheExchangeHash() throws {
-        var server = Curve25519KeyExchange(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
-        var client = Curve25519KeyExchange(ourRole: .client, previousSessionIdentifier: nil)
+        var server = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .server([.init(ed25519Key: .init())]), previousSessionIdentifier: nil)
+        var client = EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>(ourRole: .client, previousSessionIdentifier: nil)
         let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
 
         var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 1024)

--- a/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
@@ -302,9 +302,9 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
 
         // Client sends a key exchange that is _subtly_ different from the server (we just add a different key exchange mechanism to the front).
         // Annoyingly we have to offer an elliptic curve protocol to make sure it parses properly. We use P-192 as the curve, referred to by OID,
-        // because we're clearly never going to support that curve.
+        // because we're clearly never going to support that curve. Then we do Curve25519 as the fallback because it's easy.
         var clientMessage = serverMessage
-        clientMessage.keyExchangeAlgorithms = ["ecdsa-sha2-1.2.840.10045.3.1.1"] + serverMessage.keyExchangeAlgorithms
+        clientMessage.keyExchangeAlgorithms = ["ecdsa-sha2-1.2.840.10045.3.1.1", "curve25519-sha256"]
         clientMessage.firstKexPacketFollows = true
         try self.assertGeneratesNoMessage(server.handle(keyExchange: clientMessage))
 


### PR DESCRIPTION
Motivation:

Previously we supported only one key exchange algorithm: x25519.
While x25519 is great, it would be good to slightly broaden out this
range to the well-supported NIST curves for improved compatibility. This
also gives us access to P384 and P521, which have wider keyspaces and
therefore (in principle) stronger levels of effective security.

Modifications:

- Refactor Cruve25519KeyExchange to become generic
  EllipticCurveKeyExchange implementation.
- Reimplemented Curve25519 key exchange in terms of this new
  implementation.
- Added P256/P384/P521 implementations for key exchange.
- Added testing!

Results:

Wider range of supported key exchange algorithms.