### PR TITLE
Support OpenSSH public key format.

### DIFF
--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -123,6 +123,11 @@ extension NIOSSHError {
     internal static func invalidHostKeyForKeyExchange(expected: Substring, got actual: String.UTF8View) -> NIOSSHError {
         NIOSSHError(type: .invalidHostKeyForKeyExchange, diagnostics: "Expected \(String(expected)), got \(String(actual))")
     }
+
+    @inline(never)
+    internal static func invalidOpenSSHPublicKey(reason: String) -> NIOSSHError {
+        NIOSSHError(type: .invalidOpenSSHPublicKey, diagnostics: reason)
+    }
 }
 
 // MARK: - NIOSSHError CustomStringConvertible conformance.
@@ -167,6 +172,7 @@ extension NIOSSHError {
             case missingGlobalRequestResponse
             case remotePeerDoesNotSupportMessage
             case invalidHostKeyForKeyExchange
+            case invalidOpenSSHPublicKey
         }
 
         private var base: Base
@@ -258,6 +264,9 @@ extension NIOSSHError {
 
         /// The peer has sent a host key that does not correspond to the one negotiated in key exchange.
         public static let invalidHostKeyForKeyExchange: ErrorType = .init(.invalidHostKeyForKeyExchange)
+
+        /// The OpenSSH public key string could not be parsed.
+        public static let invalidOpenSSHPublicKey: ErrorType = .init(.invalidOpenSSHPublicKey)
     }
 }
 

--- a/Tests/NIOSSHTests/HostKeyTests.swift
+++ b/Tests/NIOSSHTests/HostKeyTests.swift
@@ -297,4 +297,54 @@ final class HostKeyTests: XCTestCase {
             XCTAssertEqual((error as? NIOSSHError).map { $0.type }, .unknownSignature)
         }
     }
+
+    func testLoadingEd25519KeyFromFileRoundTrips() throws {
+        let keyData = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJfkNV4OS33ImTXvorZr72q4v5XhVEQKfvqsxOEJ/XaR lukasa@MacBook-Pro.local"
+        XCTAssertNoThrow(try self.roundTripKey(keyData: keyData, label: "ssh-ed25519", comment: " lukasa@MacBook-Pro.local"))
+    }
+
+    func testLoadingP256KeyFromFileRoundTrips() throws {
+        let keyData = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIZS1APJofiPeoATC/VC4kKi7xRPdz934nSkFLTc0whYi3A8hEKHAOX9edgL1UWxRqRGQZq2wvvAIjAO9kCeiQA= lukasa@MacBook-Pro.local"
+        XCTAssertNoThrow(try self.roundTripKey(keyData: keyData, label: "ecdsa-sha2-nistp256", comment: " lukasa@MacBook-Pro.local"))
+    }
+
+    func testLoadingP384KeyFromFileRoundTrips() throws {
+        let keyData = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBJPOgAXHijSxoZBiyhSDOR3eUELUoc+hqh/SY1Wq4/562jThf6Q+tjVzZTMWZMAP4S6DD2qZswsRvisxXkcZDOw5bvyk0WmezYvjUP6TZII/0BDVTotCf4SxukEtcqBZqg== lukasa@MacBook-Pro.local"
+        XCTAssertNoThrow(try self.roundTripKey(keyData: keyData, label: "ecdsa-sha2-nistp384", comment: " lukasa@MacBook-Pro.local"))
+    }
+
+    func testLoadingP521KeyFromFileRoundTrips() throws {
+        let keyData = "ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBACkfM3aZf9sgjAkncWtK6A295sdghn1GG1BKJ+hQfD2VBIJxSQDnPOocNIQQZEo3zs1kvwUXOIgWANJqbOiv77tCACxWRRYmAvM3hzgcEOhPROROG+KGvuDAWW6ZuCkaW0QnseR7Yn0+q/+/jai3tNNDWrbVLDesDj5Aq5xq1yrKDHGEA== lukasa@MacBook-Pro.local"
+        XCTAssertNoThrow(try self.roundTripKey(keyData: keyData, label: "ecdsa-sha2-nistp521", comment: " lukasa@MacBook-Pro.local"))
+    }
+
+    func testMissingCommentIsTolerated() throws {
+        let keyData = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJfkNV4OS33ImTXvorZr72q4v5XhVEQKfvqsxOEJ/XaR"
+        XCTAssertNoThrow(try self.roundTripKey(keyData: keyData, label: "ssh-ed25519", comment: ""))
+    }
+
+    func testDripFeedingKey() throws {
+        let keyData = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJfkNV4OS33ImTXvorZr72q4v5XhVEQKfvqsxOEJ/XaR"
+        for index in keyData.indices.dropLast() {
+            XCTAssertThrowsError(try NIOSSHPublicKey(openSSHPublicKey: String(keyData[..<index]))) { error in
+                XCTAssertEqual((error as? NIOSSHError)?.type, .invalidOpenSSHPublicKey)
+            }
+        }
+    }
+
+    func testKeyLiesAboutItsType() throws {
+        // Secretly P384
+        let keyData = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODQAAABhBJPOgAXHijSxoZBiyhSDOR3eUELUoc+hqh/SY1Wq4/562jThf6Q+tjVzZTMWZMAP4S6DD2qZswsRvisxXkcZDOw5bvyk0WmezYvjUP6TZII/0BDVTotCf4SxukEtcqBZqg== lukasa@MacBook-Pro.local"
+        XCTAssertThrowsError(try NIOSSHPublicKey(openSSHPublicKey: keyData)) { error in
+            XCTAssertEqual((error as? NIOSSHError)?.type, .invalidOpenSSHPublicKey)
+        }
+    }
+
+    private func roundTripKey(keyData: String, label: String, comment: String) throws {
+        let key = try assertNoThrowWithValue(NIOSSHPublicKey(openSSHPublicKey: keyData))
+        var keyBuffer = ByteBufferAllocator().buffer(capacity: 1024)
+        keyBuffer.writeSSHHostKey(key)
+        let expectedKeyData = "\(label) \(keyBuffer.readData(length: keyBuffer.readableBytes)!.base64EncodedString())\(comment)"
+        XCTAssertEqual(keyData, expectedKeyData)
+    }
 }


### PR DESCRIPTION
Motivation:

It'll be useful to be able to deserialize the OpenSSH public key format,
so let's add some hooks for doing that!

Modifications:

- Add parser for OpenSSH public key format.

Result:

Can parse OpenSSH public keys.