### PR TITLE
Allow users to verify SSH host keys.

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsKeyExchangeMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsKeyExchangeMessages.swift
@@ -41,7 +41,7 @@ extension AcceptsKeyExchangeMessages {
 
     mutating func receiveKeyExchangeReplyMessage(_ message: SSHMessage.KeyExchangeECDHReplyMessage) throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {
         let message = try self.keyExchangeStateMachine.handle(keyExchangeReply: message)
-        return .emitMessage(message)
+        return .possibleFutureMessage(message)
     }
 
     mutating func receiveNewKeysMessage() throws {

--- a/Sources/NIOSSH/Connection State Machine/States/KeyExchangeState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/KeyExchangeState.swift
@@ -33,13 +33,13 @@ extension SSHConnectionStateMachine {
         /// The backing state machine.
         var keyExchangeStateMachine: SSHKeyExchangeStateMachine
 
-        init(sentVersionState state: SentVersionState, allocator: ByteBufferAllocator, remoteVersion: String) {
+        init(sentVersionState state: SentVersionState, allocator: ByteBufferAllocator, loop: EventLoop, remoteVersion: String) {
             self.role = state.role
             self.parser = state.parser
             self.serializer = state.serializer
             self.remoteVersion = remoteVersion
             self.protectionSchemes = state.protectionSchemes
-            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, role: state.role, remoteVersion: remoteVersion, protectionSchemes: state.protectionSchemes, previousSessionIdentifier: nil)
+            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: state.role, remoteVersion: remoteVersion, protectionSchemes: state.protectionSchemes, previousSessionIdentifier: nil)
         }
     }
 }

--- a/Sources/NIOSSH/Connection State Machine/States/ReceivedKexInitWhenActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/ReceivedKexInitWhenActiveState.swift
@@ -34,14 +34,14 @@ extension SSHConnectionStateMachine {
 
         internal var sessionIdentifier: ByteBuffer
 
-        init(_ previous: ActiveState, allocator: ByteBufferAllocator) {
+        init(_ previous: ActiveState, allocator: ByteBufferAllocator, loop: EventLoop) {
             self.role = previous.role
             self.serializer = previous.serializer
             self.parser = previous.parser
             self.remoteVersion = previous.remoteVersion
             self.protectionSchemes = previous.protectionSchemes
             self.sessionIdentifier = previous.sessionIdentifier
-            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, role: previous.role, remoteVersion: previous.remoteVersion, protectionSchemes: previous.protectionSchemes, previousSessionIdentifier: self.sessionIdentifier)
+            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: previous.role, remoteVersion: previous.remoteVersion, protectionSchemes: previous.protectionSchemes, previousSessionIdentifier: self.sessionIdentifier)
         }
     }
 }

--- a/Sources/NIOSSH/Connection State Machine/States/SentKexInitWhenActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentKexInitWhenActiveState.swift
@@ -34,14 +34,14 @@ extension SSHConnectionStateMachine {
 
         internal var keyExchangeStateMachine: SSHKeyExchangeStateMachine
 
-        init(_ previous: ActiveState, allocator: ByteBufferAllocator) {
+        init(_ previous: ActiveState, allocator: ByteBufferAllocator, loop: EventLoop) {
             self.role = previous.role
             self.serializer = previous.serializer
             self.parser = previous.parser
             self.remoteVersion = previous.remoteVersion
             self.protectionSchemes = previous.protectionSchemes
             self.sessionIdentitifier = previous.sessionIdentifier
-            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, role: self.role, remoteVersion: self.remoteVersion, protectionSchemes: self.protectionSchemes, previousSessionIdentifier: previous.sessionIdentifier)
+            self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: self.role, remoteVersion: self.remoteVersion, protectionSchemes: self.protectionSchemes, previousSessionIdentifier: previous.sessionIdentifier)
         }
     }
 }

--- a/Sources/NIOSSH/Keys And Signatures/ClientServerAuthenticationDelegate.swift
+++ b/Sources/NIOSSH/Keys And Signatures/ClientServerAuthenticationDelegate.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+/// A `NIOSSHClientSErverAuthenticationDelegate` is an object that can validate whether
+/// a server host key is trusted.
+///
+/// When an SSH connection is performing key exchange, the SSH server will send over its host
+/// key. This should be validated by the client before the connection proceeds. This callback
+/// allows clients to perform that validation.
+public protocol NIOSSHClientServerAuthenticationDelegate {
+    /// Invoked to validate a specific host key. Implementations should succeed the `validationCompletePromise`
+    /// if they trust the host key, or fail it if they do not.
+    func validateHostKey(hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>)
+}

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -419,7 +419,7 @@ extension NIOSSHHandler {
     internal func _rekey() throws {
         // As this is test-only there are a bunch of preconditions in here, we don't really mind if we hit them in testing.
         var buffer = self.context!.channel.allocator.buffer(capacity: 1024)
-        try self.stateMachine.beginRekeying(buffer: &buffer, allocator: self.context!.channel.allocator)
+        try self.stateMachine.beginRekeying(buffer: &buffer, allocator: self.context!.channel.allocator, loop: self.context!.eventLoop)
         self.context!.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
     }
 }

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -17,11 +17,17 @@ public struct SSHClientConfiguration {
     /// The user authentication delegate to be used with this client.
     public var userAuthDelegate: NIOSSHClientUserAuthenticationDelegate
 
+    /// The server authentication delegate to be used with this client.
+    public var serverAuthDelegate: NIOSSHClientServerAuthenticationDelegate
+
     /// The global request delegate to be used with this client.
     public var globalRequestDelegate: GlobalRequestDelegate
 
-    public init(userAuthDelegate: NIOSSHClientUserAuthenticationDelegate, globalRequestDelegate: GlobalRequestDelegate? = nil) {
+    public init(userAuthDelegate: NIOSSHClientUserAuthenticationDelegate,
+                serverAuthDelegate: NIOSSHClientServerAuthenticationDelegate,
+                globalRequestDelegate: GlobalRequestDelegate? = nil) {
         self.userAuthDelegate = userAuthDelegate
+        self.serverAuthDelegate = serverAuthDelegate
         self.globalRequestDelegate = globalRequestDelegate ?? DefaultGlobalRequestDelegate()
     }
 }

--- a/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
+++ b/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
@@ -17,7 +17,7 @@ import NIOSSH
 
 final class BenchmarkHandshake: Benchmark {
     let serverRole = SSHConnectionRole.server(.init(hostKeys: [.init(ed25519Key: .init())], userAuthDelegate: ExpectPasswordDelegate("password")))
-    let clientRole = SSHConnectionRole.client(.init(userAuthDelegate: RepeatingPasswordDelegate("password")))
+    let clientRole = SSHConnectionRole.client(.init(userAuthDelegate: RepeatingPasswordDelegate("password"), serverAuthDelegate: ClientAlwaysAcceptHostKeyDelegate()))
     let loopCount: Int
 
     init(loopCount: Int) {

--- a/Sources/NIOSSHPerformanceTester/shared.swift
+++ b/Sources/NIOSSHPerformanceTester/shared.swift
@@ -86,3 +86,9 @@ final class RepeatingPasswordDelegate: NIOSSHClientUserAuthenticationDelegate {
         }
     }
 }
+
+final class ClientAlwaysAcceptHostKeyDelegate: NIOSSHClientServerAuthenticationDelegate {
+    func validateHostKey(hostKey: NIOSSHPublicKey, validationCompletePromise: EventLoopPromise<Void>) {
+        validationCompletePromise.succeed(())
+    }
+}

--- a/Tests/NIOSSHTests/ECKeyExchangeTests.swift
+++ b/Tests/NIOSSHTests/ECKeyExchangeTests.swift
@@ -316,5 +316,5 @@ extension SSHConnectionRole {
         .server(SSHServerConfiguration(hostKeys: hostKeys, userAuthDelegate: DenyAllServerAuthDelegate()))
     }
 
-    fileprivate static let client = SSHConnectionRole.client(SSHClientConfiguration(userAuthDelegate: ExplodingAuthDelegate()))
+    fileprivate static let client = SSHConnectionRole.client(SSHClientConfiguration(userAuthDelegate: ExplodingAuthDelegate(), serverAuthDelegate: AcceptAllHostKeysDelegate()))
 }

--- a/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
@@ -216,7 +216,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testBasicHappyClientFlow() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -231,7 +231,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testBasicSadClientFlow() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -250,7 +250,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testBasicSadThenHappyClientFlow() throws {
         let delegate = InfinitePasswordDelegate()
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -270,7 +270,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testAuthMessagesAfterSuccessAreIgnored() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -289,7 +289,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testUnsolicitedResponseBeforeInitIsInvalid() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertThrowsError(try stateMachine.receiveUserAuthSuccess()) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .protocolViolation)
@@ -301,7 +301,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testUnsolicitedResponseAfterInitBeforeSendingIsInvalid() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         // Let's request the first message but not deliver it.
         _ = stateMachine.beginAuthentication()
@@ -316,7 +316,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testUnsolicitedResponseAfterFailureBeforeNextRequestIsInvalid() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -340,7 +340,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testUnsolicitedResponseAfterCompleteFailureIsInvalid() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -457,7 +457,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testClientRejectsUserAuthRequests() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
         let authRequest = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .password("bar"))
 
         XCTAssertThrowsError(try stateMachine.receiveUserAuthRequest(authRequest)) { error in
@@ -529,7 +529,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testClientsRejectUserAuthRequests() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertThrowsError(try stateMachine.receiveServiceRequest(.init(service: "ssh-userauth"))) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .protocolViolation)
@@ -538,7 +538,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testClientsRejectUnexpectedAuthServices() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
@@ -551,7 +551,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testClientsRejectServiceAcceptOutOfSequence() throws {
         let delegate = SimplePasswordDelegate(username: "foo", password: "bar")
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         // Before we start the client rejects service accepts.
         let accept = SSHMessage.ServiceAcceptMessage(service: "ssh-userauth")
@@ -701,7 +701,7 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
     func testPrivateKeyClientAuthFlow() throws {
         let delegate = InfinitePrivateKeyDelegate()
-        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate)), loop: self.loop, sessionID: self.sessionID)
+        var stateMachine = UserAuthenticationStateMachine(role: .client(.init(userAuthDelegate: delegate, serverAuthDelegate: AcceptAllHostKeysDelegate())), loop: self.loop, sessionID: self.sessionID)
 
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))


### PR DESCRIPTION
Motivation:

A major part of SSH is the requirement that we validate the host keys of
the server when they send them to us. This is not something
swift-nio-ssh has supported prior to now: we always just accepted
whatever the server sent. This is obviously not good!

We need to introduce another callback here. This callback wants to
support asynchrony because there are a number of ways to validate host
keys that cannot be done synchronously, including asking the user to
visually validate that key.

This is fine, we have good patterns for doing this.

Unfortunately, what's new is that prior to this point we always assumed
we'd emit newKeys synchronously as soon as we could, which was always on
receipt of a remote message from the server. This would allow us to
_also_ immediately send the session request that follows. That is no
longer true! If the user is validating the server host key, we cannot
send that session request, because we won't send newKeys until the user
has told us they're happy.

This means we need to break an assumption that's been true for a long
time, namely that sending a message won't trigger the emission of more
than one message. This has some ramifications in the testing.

Modifications:

- Update the key exchange state machine to ask a delegate to validate
  the server host key.
- Update the connection state machine to tolerate the key exchange state
  machine returning a future of a message here.
- Update the connection state machine to send the session request at the
  same time we send newKeys, which is now an arbitrary time.
- Fix the tests to stop assuming that there's only one message per
  received message.
- Tested that the key verification callback works correctly.

Results:

Users can validate SSH host keys using key verification callbacks. For
security reasons we require the key verification callback to be
provided, so updating to this release will break running code. Sorry!