### PR TITLE
Do not hold on to pending channels after close.

### DIFF
--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -113,6 +113,9 @@ extension NIOSSHHandler: ChannelDuplexHandler {
 
         self.dropAllPendingGlobalRequests(ChannelError.eof)
         self.dropUnsatisfiedGlobalRequests(ChannelError.eof)
+        while let next = self.pendingChannelInitializations.popFirst() {
+            next.promise?.fail(ChannelError.eof)
+        }
     }
 
     public func channelActive(context: ChannelHandlerContext) {

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -61,6 +61,16 @@ final class ErrorLoggingHandler: ChannelInboundHandler {
     }
 }
 
+final class ErrorClosingHandler: ChannelInboundHandler {
+    typealias InboundIn = Any
+    typealias InboundOut = Any
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        context.close(promise: nil)
+        context.fireErrorCaught(error)
+    }
+}
+
 final class ReadCountingHandler: ChannelOutboundHandler {
     typealias OutboundIn = Any
     typealias OutboundOut = Any


### PR DESCRIPTION
Motivation:

We temporarily store channel creation requests in NIOSSHHandler before
passing them to the multiplexer while we wait for the handshake to
complete. This is fine, but if for any reason we get removed from the
pipeline while we're still holding some, they must all be cancelled.

Modifications:

- Correctly cancel creation requests on handlerRemoved.
- Verify behaviour in tests.

Result:

Fewer hangs on channel creation.

Actually fixes #36.