### PR TITLE
No creating SSH channels after disconnect.

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -1087,6 +1087,17 @@ extension SSHConnectionStateMachine {
         }
     }
 
+    /// Like `isActive`, but covers all states past `.active`.
+    var hasActivated: Bool {
+        switch self.state {
+        case .active, .receivedKexInitWhenActive, .sentKexInitWhenActive, .rekeying, .rekeyingReceivedNewKeysState,
+             .rekeyingSentNewKeysState, .receivedDisconnect, .sentDisconnect:
+            return true
+        case .idle, .sentVersion, .keyExchange, .receivedNewKeys, .sentNewKeys, .userAuthentication:
+            return false
+        }
+    }
+
     var role: SSHConnectionRole {
         switch self.state {
         case .idle(let state):


### PR DESCRIPTION
Motivation:

If the channel has been disconnected, we should forbid any attempt to
create an SSH channel. While we have a number of ways to catch this, in
some weirder environments it's possible none of them succeed, so let's
take a wider view of how to create these channels by preventing them
being created as early as possible as well.

Modifications:

- Change early-exit guard to only fire during the first handshake.
- If we are in the disconnected state, drop channel creation
  immediately.

Result:

Better defense against losing channel creation events.