### PR TITLE
Initialize state machine on handlerAdded

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -68,14 +68,14 @@ struct SSHConnectionStateMachine {
         self.state = .idle(IdleState(role: role, protectionSchemes: protectionSchemes))
     }
 
-    func start() -> SSHMultiMessage {
+    func start() -> SSHMultiMessage? {
         switch self.state {
         case .idle:
             return SSHMultiMessage(SSHMessage.version(Constants.version))
         case .sentVersion, .keyExchange, .sentNewKeys, .receivedNewKeys, .userAuthentication,
              .active, .receivedKexInitWhenActive, .sentKexInitWhenActive, .rekeying, .rekeyingReceivedNewKeysState,
              .rekeyingSentNewKeysState, .receivedDisconnect, .sentDisconnect:
-            preconditionFailure("Cannot call start twice, state \(self.state)")
+            return nil
         }
     }
 

--- a/Tests/NIOSSHTests/SSHHandlerTests.swift
+++ b/Tests/NIOSSHTests/SSHHandlerTests.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2019 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIO
+@testable import NIOSSH
+import XCTest
+
+class SSHHandlerTests: XCTestCase {
+    func testHandlerInitializationOnAdd() throws {
+        let allocator = ByteBufferAllocator()
+        let channel = EmbeddedChannel()
+        let handler = NIOSSHHandler(role: .client(.init(userAuthDelegate: InfinitePasswordDelegate(), serverAuthDelegate: AcceptAllHostKeysDelegate())), allocator: allocator, inboundChildChannelInitializer: nil)
+
+        _ = try channel.connect(to: .init(unixDomainSocketPath: "/foo"))
+
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
+        XCTAssertEqual(try channel.readOutbound(as: IOData.self), .byteBuffer(allocator.buffer(string: Constants.version + "\r\n")))
+    }
+
+    func testHandlerInitializationActive() throws {
+        let allocator = ByteBufferAllocator()
+        let channel = EmbeddedChannel()
+        let handler = NIOSSHHandler(role: .client(.init(userAuthDelegate: InfinitePasswordDelegate(), serverAuthDelegate: AcceptAllHostKeysDelegate())), allocator: allocator, inboundChildChannelInitializer: nil)
+
+        XCTAssertNoThrow(try channel.pipeline.addHandler(handler).wait())
+        XCTAssertNil(try channel.readOutbound())
+
+        _ = try channel.connect(to: .init(unixDomainSocketPath: "/foo"))
+        XCTAssertEqual(try channel.readOutbound(as: IOData.self), .byteBuffer(allocator.buffer(string: Constants.version + "\r\n")))
+    }
+}


### PR DESCRIPTION
Motivation:
Sometimes we already have an established channel, for example,
one returned by establishing a tunneled connection. If this
is the case, then we cannot use it to start key exchange, since
it's only started when channel becomes active. In order to
support more use cases we should handle starting key exchange
when handler is added as well.

Modifications:
1. Extract key exchange initialization to separate function
2. Call it from handlerAdded if channel is active
3. Guard againts calling it twice

Result:
Fixes #42