### PR TITLE
Use newer bytebuffer write functions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "NIOSSH", targets: ["NIOSSH"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.21.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/NIOSSH/Key Exchange/ECDHCompatibleKey.swift
+++ b/Sources/NIOSSH/Key Exchange/ECDHCompatibleKey.swift
@@ -58,7 +58,7 @@ extension Curve25519.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
     @discardableResult
     func write(to buffer: inout ByteBuffer) -> Int {
         // Curve25519 keys are essentially unstructured bags of bytes. It's great.
-        buffer.writeBytes(self.rawRepresentation)
+        buffer.writeContiguousBytes(self.rawRepresentation)
     }
 }
 
@@ -83,7 +83,7 @@ extension P256.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
 
     @discardableResult
     func write(to buffer: inout ByteBuffer) -> Int {
-        buffer.writeBytes(self.x963Representation)
+        buffer.writeContiguousBytes(self.x963Representation)
     }
 }
 
@@ -108,7 +108,7 @@ extension P384.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
 
     @discardableResult
     func write(to buffer: inout ByteBuffer) -> Int {
-        buffer.writeBytes(self.x963Representation)
+        buffer.writeContiguousBytes(self.x963Representation)
     }
 }
 
@@ -133,7 +133,7 @@ extension P521.KeyAgreement.PublicKey: ECDHCompatiblePublicKey {
 
     @discardableResult
     func write(to buffer: inout ByteBuffer) -> Int {
-        buffer.writeBytes(self.x963Representation)
+        buffer.writeContiguousBytes(self.x963Representation)
     }
 }
 

--- a/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
+++ b/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
@@ -191,7 +191,7 @@ extension EllipticCurveKeyExchange {
             sessionID = previousSessionIdentifier
         } else {
             var hashBytes = allocator.buffer(capacity: PrivateKey.Hasher.Digest.byteCount)
-            hashBytes.writeBytes(exchangeHash)
+            hashBytes.writeContiguousBytes(exchangeHash)
             sessionID = hashBytes
         }
 

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -46,7 +46,7 @@ public struct NIOSSHPublicKey: Hashable {
         }
 
         var buffer = ByteBufferAllocator().buffer(capacity: rawBytes.count)
-        buffer.writeBytes(rawBytes)
+        buffer.writeContiguousBytes(rawBytes)
         guard let key = try buffer.readSSHHostKey() else {
             throw NIOSSHError.invalidOpenSSHPublicKey(reason: "incomplete key data")
         }

--- a/Sources/NIOSSH/TransportProtection/AESGCM.swift
+++ b/Sources/NIOSSH/TransportProtection/AESGCM.swift
@@ -171,7 +171,7 @@ extension AESGCMTransportProtection: NIOSSHTransportProtection {
         // We now want to overwrite the portion of the bytebuffer that contains the plaintext with the ciphertext, and then append the
         // tag.
         outboundBuffer.setBytes(sealedBox.ciphertext, at: packetPaddingIndex)
-        let tagLength = outboundBuffer.writeBytes(sealedBox.tag)
+        let tagLength = outboundBuffer.writeContiguousBytes(sealedBox.tag)
         precondition(tagLength == self.macBytes, "Unexpected short tag")
 
         // Now we increment the Nonce for the next use, and then we're done!

--- a/Sources/NIOSSHServer/ExecHandler.swift
+++ b/Sources/NIOSSHServer/ExecHandler.swift
@@ -132,7 +132,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
                         }
 
                         var buffer = channel.allocator.buffer(capacity: data.count)
-                        buffer.writeBytes(data)
+                        buffer.writeContiguousBytes(data)
                         channel.write(SSHChannelData(type: .stdErr, data: .byteBuffer(buffer)), promise: nil)
                     }
                 }

--- a/Tests/NIOSSHTests/AESGCMTests.swift
+++ b/Tests/NIOSSHTests/AESGCMTests.swift
@@ -298,7 +298,7 @@ final class AESGCMTests: XCTestCase {
 
         for ciphertextSize in invalidSizes {
             buffer.clear()
-            buffer.writeBytes(repeatElement(42, count: ciphertextSize))
+            buffer.writeRepeatingByte(42, count: ciphertextSize)
 
             XCTAssertThrowsError(try aes128.decryptAndVerifyRemainingPacket(&buffer)) { error in
                 XCTAssertEqual((error as? NIOSSHError)?.type, .invalidEncryptedPacketLength)
@@ -318,7 +318,7 @@ final class AESGCMTests: XCTestCase {
 
         for ciphertextSize in invalidSizes {
             buffer.clear()
-            buffer.writeBytes(repeatElement(42, count: ciphertextSize))
+            buffer.writeRepeatingByte(42, count: ciphertextSize)
 
             XCTAssertThrowsError(try aes256.decryptAndVerifyRemainingPacket(&buffer)) { error in
                 XCTAssertEqual((error as? NIOSSHError)?.type, .invalidEncryptedPacketLength)
@@ -334,7 +334,7 @@ final class AESGCMTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeInteger(UInt32(36)) // We need the length bytes in order to authenticate them.
         buffer.writeInteger(UInt8(16))
-        buffer.writeBytes(repeatElement(0, count: 15))
+        buffer.writeRepeatingByte(0, count: 15)
 
         // We now need to turn this into an SSH packet. This is sadly just reproducing the encryption logic.
         let keys = self.generateKeys(keySize: .bits128)
@@ -345,7 +345,7 @@ final class AESGCMTests: XCTestCase {
         let writtenBytes = buffer.setBytes(box.ciphertext, at: 4)
         XCTAssertEqual(writtenBytes, 16)
 
-        buffer.writeBytes(box.tag)
+        buffer.writeContiguousBytes(box.tag)
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
@@ -363,7 +363,7 @@ final class AESGCMTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeInteger(UInt32(36)) // We need the length bytes in order to authenticate them.
         buffer.writeInteger(UInt8(16))
-        buffer.writeBytes(repeatElement(0, count: 15))
+        buffer.writeRepeatingByte(0, count: 15)
 
         // We now need to turn this into an SSH packet. This is sadly just reproducing the encryption logic.
         let keys = self.generateKeys(keySize: .bits256)
@@ -374,7 +374,7 @@ final class AESGCMTests: XCTestCase {
         let writtenBytes = buffer.setBytes(box.ciphertext, at: 4)
         XCTAssertEqual(writtenBytes, 16)
 
-        buffer.writeBytes(box.tag)
+        buffer.writeContiguousBytes(box.tag)
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
@@ -392,7 +392,7 @@ final class AESGCMTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeInteger(UInt32(36)) // We need the length bytes in order to authenticate them.
         buffer.writeInteger(UInt8(3))
-        buffer.writeBytes(repeatElement(0, count: 15))
+        buffer.writeRepeatingByte(0, count: 15)
 
         // We now need to turn this into an SSH packet. This is sadly just reproducing the encryption logic.
         let keys = self.generateKeys(keySize: .bits128)
@@ -403,7 +403,7 @@ final class AESGCMTests: XCTestCase {
         let writtenBytes = buffer.setBytes(box.ciphertext, at: 4)
         XCTAssertEqual(writtenBytes, 16)
 
-        buffer.writeBytes(box.tag)
+        buffer.writeContiguousBytes(box.tag)
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.
@@ -421,7 +421,7 @@ final class AESGCMTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
         buffer.writeInteger(UInt32(36)) // We need the length bytes in order to authenticate them.
         buffer.writeInteger(UInt8(3))
-        buffer.writeBytes(repeatElement(0, count: 15))
+        buffer.writeRepeatingByte(0, count: 15)
 
         // We now need to turn this into an SSH packet. This is sadly just reproducing the encryption logic.
         let keys = self.generateKeys(keySize: .bits256)
@@ -432,7 +432,7 @@ final class AESGCMTests: XCTestCase {
         let writtenBytes = buffer.setBytes(box.ciphertext, at: 4)
         XCTAssertEqual(writtenBytes, 16)
 
-        buffer.writeBytes(box.tag)
+        buffer.writeContiguousBytes(box.tag)
         XCTAssertEqual(buffer.readableBytes, 36)
 
         // We can now attempt to decrypt this packet.

--- a/Tests/NIOSSHTests/ByteBuffer+SSHTests.swift
+++ b/Tests/NIOSSHTests/ByteBuffer+SSHTests.swift
@@ -54,10 +54,10 @@ final class ByteBufferSSHTests: XCTestCase {
         buffer.writeBytes("hello world!".utf8) // Simple utf8 string
 
         buffer.writeInteger(UInt32(5))
-        buffer.writeBytes(repeatElement(0, count: 5)) // All nulls string
+        buffer.writeRepeatingByte(0, count: 5) // All nulls string
 
         buffer.writeInteger(UInt32(5))
-        buffer.writeBytes(repeatElement(42, count: 3)) // Short string
+        buffer.writeRepeatingByte(42, count: 3) // Short string
 
         XCTAssertEqual(buffer.getSSHString(at: 0)?.array, [])
         XCTAssertEqual(buffer.getSSHString(at: 4)?.array, Array("hello world!".utf8))
@@ -78,10 +78,10 @@ final class ByteBufferSSHTests: XCTestCase {
         buffer.writeBytes("hello world!".utf8) // Simple utf8 string
 
         buffer.writeInteger(UInt32(5))
-        buffer.writeBytes(repeatElement(0, count: 5)) // All nulls string
+        buffer.writeRepeatingByte(0, count: 5) // All nulls string
 
         buffer.writeInteger(UInt32(5))
-        buffer.writeBytes(repeatElement(42, count: 3)) // Short string
+        buffer.writeRepeatingByte(42, count: 3) // Short string
 
         XCTAssertEqual(buffer.readSSHString()?.array, [])
         XCTAssertEqual(buffer.readSSHString()?.array, Array("hello world!".utf8))

--- a/Tests/NIOSSHTests/FuzzResultTests.swift
+++ b/Tests/NIOSSHTests/FuzzResultTests.swift
@@ -50,7 +50,7 @@ final class FuzzResultTests: XCTestCase {
 
     private func runTest(base64EncodedTestData testBytes: String) {
         var buffer = self.channel.allocator.buffer(capacity: testBytes.utf8.count) // Too big, but ok.
-        buffer.writeBytes(Data(base64Encoded: testBytes)!)
+        buffer.writeContiguousBytes(Data(base64Encoded: testBytes)!)
 
         // This test must only not crash.
         _ = try? self.channel.writeInbound(buffer)


### PR DESCRIPTION
Motivation:

NIOSSH does a lot of writing of Data objects. This has been hitting a
slow-path in writeBytes that is not really ideal, so in NIO 2.21 we
added some new fast-path write functions. We should use them!

Modifications:

- Move most Data writes to writeContiguousBytes.
- Move signature writes to writeContiguousBytes.
- Replace repeated writes with writeRepeatedByte.

Result:

More efficient data writing code.