### PR TITLE
Resolve stalls in the example client.

### DIFF
--- a/Sources/NIOSSHClient/GlueHandler.swift
+++ b/Sources/NIOSSHClient/GlueHandler.swift
@@ -72,6 +72,12 @@ extension GlueHandler: ChannelDuplexHandler {
 
     func handlerAdded(context: ChannelHandlerContext) {
         self.context = context
+
+        // It's possible our partner asked if we were writable, before, and we couldn't answer.
+        // Consider updating it.
+        if context.channel.isWritable {
+            self.partner?.partnerBecameWritable()
+        }
     }
 
     func handlerRemoved(context: ChannelHandlerContext) {

--- a/Sources/NIOSSHServer/GlueHandler.swift
+++ b/Sources/NIOSSHServer/GlueHandler.swift
@@ -72,6 +72,12 @@ extension GlueHandler: ChannelDuplexHandler {
 
     func handlerAdded(context: ChannelHandlerContext) {
         self.context = context
+
+        // It's possible our partner asked if we were writable, before, and we couldn't answer.
+        // Consider updating it.
+        if context.channel.isWritable {
+            self.partner?.partnerBecameWritable()
+        }
     }
 
     func handlerRemoved(context: ChannelHandlerContext) {


### PR DESCRIPTION
Motivation:

When running the example client on extremely low latency connections it
can occasionally stall, printing nothing to stdout before exiting. This
is the result of a timing window where we receive the data before the
pipe bootstrap has been configured and our glue handlers are not in
place.

There is also another timing window where we block reads on the SSH
Child Channel because the glue handler asked if the partner was writable
before the partner was inserted into the pipe channel.

Modifications:

- Cleanup both timing windows.

Result:

The SSH client example will be substantially more reliable.