### PR TITLE
Implement client port forwarding example.

### DIFF
--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -118,4 +118,5 @@ enum SSHClientError: Swift.Error {
     case passwordAuthenticationNotSupported
     case commandExecFailed
     case invalidChannelType
+    case invalidData
 }

--- a/Sources/NIOSSHClient/PortForwardingServer.swift
+++ b/Sources/NIOSSHClient/PortForwardingServer.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import NIO
+import NIOSSH
+
+final class PortForwardingServer {
+    private var serverChannel: Channel?
+    private let serverLoop: EventLoop
+    private let group: EventLoopGroup
+    private let bindHost: Substring
+    private let bindPort: Int
+    private let forwardingChannelConstructor: (Channel) -> EventLoopFuture<Void>
+
+    init(group: EventLoopGroup,
+         bindHost: Substring,
+         bindPort: Int,
+         _ forwardingChannelConstructor: @escaping (Channel) -> EventLoopFuture<Void>) {
+        self.serverLoop = group.next()
+        self.group = group
+        self.forwardingChannelConstructor = forwardingChannelConstructor
+        self.bindHost = bindHost
+        self.bindPort = bindPort
+    }
+
+    func run() -> EventLoopFuture<Void> {
+        ServerBootstrap(group: self.serverLoop, childGroup: self.group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer(self.forwardingChannelConstructor)
+            .bind(host: String(self.bindHost), port: self.bindPort)
+            .flatMap {
+                self.serverChannel = $0
+                return $0.closeFuture
+            }
+    }
+
+    func close() -> EventLoopFuture<Void> {
+        self.serverLoop.flatSubmit {
+            guard let server = self.serverChannel else {
+                // The server wasn't created yet, so we can just shut down straight away and let
+                // the OS clean us up.
+                return self.serverLoop.makeSucceededFuture(())
+            }
+
+            return server.close()
+        }
+    }
+}
+
+/// A simple handler that wraps data into SSHChannelData for forwarding.
+final class SSHWrapperHandler: ChannelDuplexHandler {
+    typealias InboundIn = SSHChannelData
+    typealias InboundOut = ByteBuffer
+    typealias OutboundIn = ByteBuffer
+    typealias OutboundOut = SSHChannelData
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let data = self.unwrapInboundIn(data)
+
+        guard case .channel = data.type, case .byteBuffer(let buffer) = data.data else {
+            context.fireErrorCaught(SSHClientError.invalidData)
+            return
+        }
+
+        context.fireChannelRead(self.wrapInboundOut(buffer))
+    }
+
+    func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let data = self.unwrapOutboundIn(data)
+        let wrapped = SSHChannelData(type: .channel, data: .byteBuffer(data))
+        context.write(self.wrapOutboundOut(wrapped), promise: promise)
+    }
+}

--- a/Sources/NIOSSHClient/SimpleCLIParser.swift
+++ b/Sources/NIOSSHClient/SimpleCLIParser.swift
@@ -18,7 +18,24 @@ struct SimpleCLIParser {
     func parse() -> Result {
         var arguments = CommandLine.arguments.dropFirst()
 
-        // Right now we don't take flags, so the first argument must be "target"
+        // Let's start by searching for flags
+        var listen: Listen?
+        while let first = arguments.first, first.starts(with: "-") {
+            arguments = arguments.dropFirst()
+
+            switch first {
+            case "-L":
+                // The next argument is the listen string.
+                guard let next = arguments.popFirst(), let parsed = Listen(listenString: next) else {
+                    self.usage()
+                }
+                listen = parsed
+            default:
+                self.usage()
+            }
+        }
+
+        // The first argument must be "target"
         guard var target = arguments.popFirst() else {
             self.usage()
         }
@@ -34,11 +51,11 @@ struct SimpleCLIParser {
         }
         let command = arguments.joined(separator: " ")
 
-        return Result(commandString: command, target: targetURL)
+        return Result(commandString: command, target: targetURL, listen: listen)
     }
 
     private func usage() -> Never {
-        print("NIOSSHClient destination command...")
+        print("NIOSSHClient [-L listenString] destination command...")
         exit(1)
     }
 }
@@ -55,12 +72,47 @@ extension SimpleCLIParser {
 
         var password: String?
 
-        fileprivate init(commandString: String?, target: URL) {
+        var listen: Listen?
+
+        fileprivate init(commandString: String?, target: URL, listen: Listen?) {
             self.commandString = commandString ?? "uname -a"
             self.host = target.host ?? "::1"
             self.port = target.port ?? 22
             self.user = target.user
             self.password = target.password
+            self.listen = listen
+        }
+    }
+}
+
+extension SimpleCLIParser {
+    // A structure representing a parsed listen string: [bind_address:]port:host:hostport
+    struct Listen {
+        var bindHost: Substring?
+        var bindPort: Int
+        var targetHost: Substring
+        var targetPort: Int
+
+        init?(listenString: String) {
+            var components = listenString.split(separator: ":")
+
+            switch components.count {
+            case 4:
+                self.bindHost = components.removeFirst()
+                fallthrough
+            case 3:
+                guard let bindPort = Int(components.removeFirst()) else {
+                    return nil
+                }
+                self.bindPort = bindPort
+                self.targetHost = components.removeFirst()
+                guard let targetPort = Int(components.removeFirst()) else {
+                    return nil
+                }
+                self.targetPort = targetPort
+            default:
+                return nil
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

Implementing port forwarding is not always obvious, especially if
you're new to NIO. We should provide some example code.

Modifications:

- Implemented client direct port forwarding example.

Result:

Easier to explain to users what you have to do.