### PR TITLE
Add a ChannelOption for a server to query the authenticated username.

### DIFF
--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -53,4 +53,11 @@ extension SSHChildChannelOptions.Types {
 
         public init() {}
     }
+    
+    /// `UsernameOption` allows users to query the authenticated username of the channel.
+    public struct UsernameOption: ChannelOption {
+        public typealias Value = String?
+        
+        public init() {}
+    }
 }

--- a/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
@@ -93,6 +93,9 @@ extension SSHChannelMultiplexer {
             self.erroredChannels.append(channelID)
         }
     }
+    
+    // The username which the server accepted in authorization
+    var username : String? { (delegate as? NIOSSHHandler)?.username }
 }
 
 // MARK: Calls from SSH handlers.

--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -222,6 +222,8 @@ extension SSHChildChannel: Channel, ChannelCore {
             // This force-unwrap is safe: we set type before we call the initializer, so
             // users can only get this after this value is set.
             return self.type! as! Option.Value
+        case _ as SSHChildChannelOptions.Types.UsernameOption:
+            return multiplexer.username as! Option.Value
         case _ as ChannelOptions.Types.AutoReadOption:
             return self.autoRead as! Option.Value
         case _ as ChannelOptions.Types.AllowRemoteHalfClosureOption:

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -41,7 +41,7 @@ extension AcceptsUserAuthMessages {
         let result = try self.userAuthStateMachine.receiveUserAuthRequest(message)
 
         if let future = result {
-            return .possibleFutureMessage(future.map(Self.transform(_:)))
+            return .possibleFutureMessage(future.map{ Self.transform($0, username: message.username) } )
         } else {
             return .noMessage
         }
@@ -65,10 +65,10 @@ extension AcceptsUserAuthMessages {
         }
     }
 
-    private static func transform(_ result: NIOSSHUserAuthenticationResponseMessage) -> SSHMultiMessage {
+    private static func transform(_ result: NIOSSHUserAuthenticationResponseMessage, username: String?) -> SSHMultiMessage {
         switch result {
         case .success:
-            return SSHMultiMessage(.userAuthSuccess)
+            return SSHMultiMessage(.userAuthSuccess(username))
         case .failure(let message):
             return SSHMultiMessage(.userAuthFailure(message))
         case .publicKeyOK(let message):

--- a/Sources/NIOSSH/Connection State Machine/Operations/SendsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/SendsUserAuthMessages.swift
@@ -38,7 +38,7 @@ extension SendsUserAuthMessages {
 
     mutating func writeUserAuthSuccess(into buffer: inout ByteBuffer) throws {
         self.userAuthStateMachine.sendUserAuthSuccess()
-        try self.serializer.serialize(message: .userAuthSuccess, to: &buffer)
+        try self.serializer.serialize(message: .userAuthSuccess(nil), to: &buffer)
     }
 
     mutating func writeUserAuthFailure(_ message: SSHMessage.UserAuthFailureMessage, into buffer: inout ByteBuffer) throws {

--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -59,7 +59,10 @@ struct SSHConnectionStateMachine {
 
     /// The state of this state machine.
     private var state: State
-
+    
+    /// The username which authenticated to the server, if that has happened
+    private(set) var username: String? = nil
+    
     private static let defaultTransportProtectionSchemes: [NIOSSHTransportProtection.Type] = [
         AES256GCMOpenSSHTransportProtection.self, AES128GCMOpenSSHTransportProtection.self,
     ]
@@ -810,7 +813,8 @@ struct SSHConnectionStateMachine {
                 try state.writeUserAuthRequest(message, into: &buffer)
                 self.state = .userAuthentication(state)
 
-            case .userAuthSuccess:
+            case .userAuthSuccess(let username):
+                self.username = username
                 try state.writeUserAuthSuccess(into: &buffer)
                 // Ok we're good to go!
                 self.state = .active(ActiveState(state))

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -57,6 +57,9 @@ public final class NIOSSHHandler {
 
     private var pendingGlobalRequestResponses: CircularBuffer<PendingGlobalRequestResponse?>
 
+    // The authenticated username, if there was one.
+    var username: String? { stateMachine.username }
+    
     public init(role: SSHConnectionRole, allocator: ByteBufferAllocator, inboundChildChannelInitializer: ((Channel, SSHChannelType) -> EventLoopFuture<Void>)?) {
         self.stateMachine = SSHConnectionStateMachine(role: role)
         self.pendingWrite = false

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -35,7 +35,7 @@ enum SSHMessage: Equatable {
     case newKeys
     case userAuthRequest(UserAuthRequestMessage)
     case userAuthFailure(UserAuthFailureMessage)
-    case userAuthSuccess
+    case userAuthSuccess(String?)
     case userAuthPKOK(UserAuthPKOKMessage)
     case globalRequest(GlobalRequestMessage)
     case requestSuccess(RequestSuccessMessage)
@@ -418,7 +418,7 @@ extension ByteBuffer {
                 }
                 return .userAuthFailure(message)
             case SSHMessage.UserAuthSuccessMessage.id:
-                return .userAuthSuccess
+                return .userAuthSuccess(nil)
             case SSHMessage.UserAuthPKOKMessage.id:
                 guard let message = try self.readUserAuthPKOKMessage() else {
                     return nil

--- a/Tests/NIOSSHTests/SSHMessagesTests.swift
+++ b/Tests/NIOSSHTests/SSHMessagesTests.swift
@@ -389,7 +389,7 @@ final class SSHMessagesTests: XCTestCase {
 
     func testUserAuthSuccess() throws {
         var buffer = ByteBufferAllocator().buffer(capacity: 100)
-        let message = SSHMessage.userAuthSuccess
+        let message = SSHMessage.userAuthSuccess(nil)
 
         buffer.writeSSHMessage(message)
         XCTAssertEqual(try buffer.readSSHMessage(), message)


### PR DESCRIPTION
Some servers will need to know which user authenticated. This PR exposes that information through a `ChannelOption` named `SSHChildChannelOptions.Types. UsernameOption` which is a `String?` of the username if authenticated, otherwise nil.

The new code passes the `username` along with the chain of possible completions from an authentication request until it reaches the creation of the `.userAuthSuccess` message. This message is augmented with an associated `String?` to hold the username. Eventually, this message will arrive at the `SSHConnectionStateMachine`, where it will be recorded.

The `NIOSSHHandler` contains the `SSHConnectionStateMachine`, and there is a parent path reaching up from the `SSHChildHandler` to the `NIOSSHHandler`. This path is festooned with `var username:String?` properties to allow 
the `SSHChildHandler` to reach up and back down to get the username when the `UsernameOption` is requested.

I wonder a bit about adding the associated type to the `.userAuthSuccess` SSHMessage, but most of them have associated 
data already. I had to add explicit `nil` values wherever they are created without a username.

I could have stored the actual username directly in the `NIOSSHHandler`, but that would have required adding a per-message inspection in `NIOSSHHandler`. It was already being done in `SSHConnectionStateMachine`, but there isn't a parent link back up to set the value in `NIOSSHHandler`.

I didn't find a test which sets up a server and checks its behavior in order to write tests. I note that the other `ChannelOption`s are also untested and suspect that has something to do with it. My knowledge of NIO stops a little
short of understanding the `BackToBackEmbeddedChannel` test harness. I've been testing the PR from my SSHConsole 
project's `echo` server and it appears to work fine.