### PR TITLE
Add support for custom public-private key authentication types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
     ],
     products: [
         .library(name: "NIOSSH", targets: ["NIOSSH"]),
+        .library(name: "NIOSSHRSA", targets: ["NIOSSHRSA"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.21.0"),
@@ -32,7 +33,8 @@ let package = Package(
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.2.0"),
     ],
     targets: [
-        .target(name: "NIOSSH", dependencies: ["NIO", "NIOFoundationCompat", "Crypto", "BigInt"]),
+        .target(name: "NIOSSH", dependencies: ["NIO", "NIOFoundationCompat", "Crypto"]),
+        .target(name: "NIOSSHRSA", dependencies: ["NIOSSH", "BigInt"]),
         .target(name: "NIOSSHClient", dependencies: ["NIO", "NIOSSH", "NIOConcurrencyHelpers"]),
         .target(name: "NIOSSHServer", dependencies: ["NIO", "NIOSSH", "NIOFoundationCompat", "Crypto"]),
         .target(name: "NIOSSHPerformanceTester", dependencies: ["NIO", "NIOSSH", "Crypto"]),

--- a/Package.swift
+++ b/Package.swift
@@ -28,10 +28,11 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.21.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.1.2"),
+        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.2.0"),
     ],
     targets: [
-        .target(name: "NIOSSH", dependencies: ["NIO", "NIOFoundationCompat", "Crypto"]),
+        .target(name: "NIOSSH", dependencies: ["NIO", "NIOFoundationCompat", "Crypto", "BigInt"]),
         .target(name: "NIOSSHClient", dependencies: ["NIO", "NIOSSH", "NIOConcurrencyHelpers"]),
         .target(name: "NIOSSHServer", dependencies: ["NIO", "NIOSSH", "NIOFoundationCompat", "Crypto"]),
         .target(name: "NIOSSHPerformanceTester", dependencies: ["NIO", "NIOSSH", "Crypto"]),

--- a/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
+++ b/Sources/NIOSSH/Keys And Signatures/CustomKeys.swift
@@ -1,0 +1,44 @@
+import Foundation
+import NIO
+
+public protocol NIOSSHSignatureProtocol {
+    static var signaturePrefix: String { get }
+    var rawRepresentation: Data { get }
+    
+    func write(to buffer: inout ByteBuffer) -> Int
+}
+
+internal extension NIOSSHSignatureProtocol {
+    var signaturePrefix: String {
+        Self.signaturePrefix
+    }
+}
+
+public protocol NIOSSHPublicKeyProtocol {
+    static var publicKeyPrefix: String { get }
+    var rawRepresentation: Data { get }
+    
+    func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignatureProtocol, for data: D) -> Bool
+    
+    func write(to buffer: inout ByteBuffer) -> Int
+}
+
+internal extension NIOSSHPublicKeyProtocol {
+    var publicKeyPrefix: String {
+        Self.publicKeyPrefix
+    }
+}
+
+public protocol NIOSSHPrivateKeyProtocol {
+    static var keyPrefix: String { get }
+//    var rawRepresentation: Data { get }
+    var publicKey: NIOSSHPublicKeyProtocol { get }
+    
+    func signature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol
+}
+
+internal extension NIOSSHPrivateKeyProtocol {
+    var keyPrefix: String {
+        Self.keyPrefix
+    }
+}

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -328,8 +328,8 @@ extension NIOSSHCertifiedPublicKey {
             return Self.p384KeyPrefix
         case .ecdsaP521:
             return Self.p521KeyPrefix
-        case .rsa:
-            return Self.rsaKeyPrefix
+        case .custom(let backingKey):
+            return backingKey.publicKeyPrefix.utf8
         case .certified:
             preconditionFailure("base key cannot be certified")
         }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -316,6 +316,7 @@ extension NIOSSHCertifiedPublicKey {
     static let p521KeyPrefix = "ecdsa-sha2-nistp521-cert-v01@openssh.com".utf8
 
     static let ed25519KeyPrefix = "ssh-ed25519-cert-v01@openssh.com".utf8
+    static let rsaKeyPrefix = "ssh-rsa".utf8
 
     internal var keyPrefix: String.UTF8View {
         switch self.key.backingKey {
@@ -327,6 +328,8 @@ extension NIOSSHCertifiedPublicKey {
             return Self.p384KeyPrefix
         case .ecdsaP521:
             return Self.p521KeyPrefix
+        case .rsa:
+            return Self.rsaKeyPrefix
         case .certified:
             preconditionFailure("base key cannot be certified")
         }

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -45,6 +45,10 @@ public struct NIOSSHPrivateKey {
     public init(p521Key key: P521.Signing.PrivateKey) {
         self.backingKey = .ecdsaP521(key)
     }
+    
+    public init(rsa key: Insecure.RSA.Signing.PrivateKey) {
+        self.backingKey = .rsa(key)
+    }
 
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
     public init(secureEnclaveP256Key key: SecureEnclave.P256.Signing.PrivateKey) {
@@ -63,6 +67,8 @@ public struct NIOSSHPrivateKey {
             return ["ecdsa-sha2-nistp384"]
         case .ecdsaP521:
             return ["ecdsa-sha2-nistp521"]
+        case .rsa:
+            return ["ssh-rsa"]
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256:
             return ["ecdsa-sha2-nistp256"]
@@ -78,6 +84,7 @@ extension NIOSSHPrivateKey {
         case ecdsaP256(P256.Signing.PrivateKey)
         case ecdsaP384(P384.Signing.PrivateKey)
         case ecdsaP521(P521.Signing.PrivateKey)
+        case rsa(Insecure.RSA.Signing.PrivateKey)
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
@@ -108,6 +115,11 @@ extension NIOSSHPrivateKey {
                 try key.signature(for: ptr)
             }
             return NIOSSHSignature(backingSignature: .ecdsaP521(signature))
+        case .rsa(let key):
+            let signature = try digest.withUnsafeBytes { ptr in
+                try key.signature(for: ptr)
+            }
+            return NIOSSHSignature(backingSignature: .rsa(signature))
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
@@ -133,6 +145,9 @@ extension NIOSSHPrivateKey {
         case .ecdsaP521(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .ecdsaP521(signature))
+        case .rsa(let key):
+            let signature = try key.signature(for: payload.bytes.readableBytesView)
+            return NIOSSHSignature(backingSignature: .rsa(signature))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
@@ -154,6 +169,8 @@ extension NIOSSHPrivateKey {
             return NIOSSHPublicKey(backingKey: .ecdsaP384(privateKey.publicKey))
         case .ecdsaP521(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP521(privateKey.publicKey))
+        case .rsa(let privateKey):
+            return NIOSSHPublicKey(backingKey: .rsa(privateKey.publicKey))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP256(privateKey.publicKey))

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -46,8 +46,8 @@ public struct NIOSSHPrivateKey {
         self.backingKey = .ecdsaP521(key)
     }
     
-    public init(rsa key: Insecure.RSA.Signing.PrivateKey) {
-        self.backingKey = .rsa(key)
+    public init<PrivateKey: NIOSSHPrivateKeyProtocol>(custom key: PrivateKey) {
+        self.backingKey = .custom(key)
     }
 
     #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
@@ -67,8 +67,8 @@ public struct NIOSSHPrivateKey {
             return ["ecdsa-sha2-nistp384"]
         case .ecdsaP521:
             return ["ecdsa-sha2-nistp521"]
-        case .rsa:
-            return ["ssh-rsa"]
+        case .custom(let backingKey):
+            return [Substring(backingKey.keyPrefix)]
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256:
             return ["ecdsa-sha2-nistp256"]
@@ -84,7 +84,7 @@ extension NIOSSHPrivateKey {
         case ecdsaP256(P256.Signing.PrivateKey)
         case ecdsaP384(P384.Signing.PrivateKey)
         case ecdsaP521(P521.Signing.PrivateKey)
-        case rsa(Insecure.RSA.Signing.PrivateKey)
+        case custom(NIOSSHPrivateKeyProtocol)
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
@@ -115,11 +115,11 @@ extension NIOSSHPrivateKey {
                 try key.signature(for: ptr)
             }
             return NIOSSHSignature(backingSignature: .ecdsaP521(signature))
-        case .rsa(let key):
+        case .custom(let key):
             let signature = try digest.withUnsafeBytes { ptr in
                 try key.signature(for: ptr)
             }
-            return NIOSSHSignature(backingSignature: .rsa(signature))
+            return NIOSSHSignature(backingSignature: .custom(signature))
 
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
@@ -145,9 +145,9 @@ extension NIOSSHPrivateKey {
         case .ecdsaP521(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
             return NIOSSHSignature(backingSignature: .ecdsaP521(signature))
-        case .rsa(let key):
+        case .custom(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
-            return NIOSSHSignature(backingSignature: .rsa(signature))
+            return NIOSSHSignature(backingSignature: .custom(signature))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let key):
             let signature = try key.signature(for: payload.bytes.readableBytesView)
@@ -169,8 +169,8 @@ extension NIOSSHPrivateKey {
             return NIOSSHPublicKey(backingKey: .ecdsaP384(privateKey.publicKey))
         case .ecdsaP521(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP521(privateKey.publicKey))
-        case .rsa(let privateKey):
-            return NIOSSHPublicKey(backingKey: .rsa(privateKey.publicKey))
+        case .custom(let privateKey):
+            return NIOSSHPublicKey(backingKey: .custom(privateKey.publicKey))
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case .secureEnclaveP256(let privateKey):
             return NIOSSHPublicKey(backingKey: .ecdsaP256(privateKey.publicKey))

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHSignature.swift
@@ -36,7 +36,7 @@ extension NIOSSHSignature {
         case ecdsaP256(P256.Signing.ECDSASignature)
         case ecdsaP384(P384.Signing.ECDSASignature)
         case ecdsaP521(P521.Signing.ECDSASignature)
-        case rsa(Insecure.RSA.Signing.Signature)
+        case custom(NIOSSHSignatureProtocol)
 
         internal enum RawBytes {
             case byteBuffer(ByteBuffer)
@@ -55,9 +55,6 @@ extension NIOSSHSignature {
 
     /// The prefix of a P521 ECDSA public key.
     fileprivate static let ecdsaP521SignaturePrefix = "ecdsa-sha2-nistp521".utf8
-    
-    /// The prefix of a RSA public key.
-    fileprivate static let rsaSignaturePrefix = "ssh-rsa".utf8
 }
 
 extension NIOSSHSignature.BackingSignature.RawBytes: Equatable {
@@ -89,13 +86,13 @@ extension NIOSSHSignature.BackingSignature: Equatable {
             return lhs.rawRepresentation == rhs.rawRepresentation
         case (.ecdsaP521(let lhs), .ecdsaP521(let rhs)):
             return lhs.rawRepresentation == rhs.rawRepresentation
-        case (.rsa(let lhs), .rsa(let rhs)):
+        case (.custom(let lhs), .custom(let rhs)):
             return lhs.rawRepresentation == rhs.rawRepresentation
         case (.ed25519, _),
              (.ecdsaP256, _),
              (.ecdsaP384, _),
              (.ecdsaP521, _),
-             (.rsa, _):
+             (.custom, _):
             return false
         }
     }
@@ -116,8 +113,9 @@ extension NIOSSHSignature.BackingSignature: Hashable {
         case .ecdsaP521(let sig):
             hasher.combine(3)
             hasher.combine(sig.rawRepresentation)
-        case .rsa(let sig):
+        case .custom(let sig):
             hasher.combine(4)
+            hasher.combine(sig.signaturePrefix)
             hasher.combine(sig.rawRepresentation)
         }
     }
@@ -136,8 +134,8 @@ extension ByteBuffer {
             return self.writeECDSAP384Signature(baseSignature: sig)
         case .ecdsaP521(let sig):
             return self.writeECDSAP521Signature(baseSignature: sig)
-        case .rsa(let sig):
-            return self.writeRSASignature(baseSignature: sig)
+        case .custom(let sig):
+            return sig.write(to: &self)
         }
     }
 
@@ -213,16 +211,6 @@ extension ByteBuffer {
             return written
         }
 
-        return writtenLength
-    }
-    
-    private mutating func writeRSASignature(baseSignature: Insecure.RSA.Signing.Signature) -> Int {
-        var writtenLength = self.writeSSHString(NIOSSHSignature.rsaSignaturePrefix)
-
-        // For SSH-RSA, the key format is the signature without lengths or paddings
-//        writtenLength += self.writeCompositeSSHString { buffer in
-        writtenLength += self.writeSSHString(baseSignature.rawRepresentation)
-//        }
         return writtenLength
     }
 

--- a/Sources/NIOSSH/RSA.swift
+++ b/Sources/NIOSSH/RSA.swift
@@ -1,0 +1,256 @@
+import NIO
+import NIOFoundationCompat
+import BigInt
+import CCryptoBoringSSL
+import Foundation
+import Crypto
+
+extension Insecure {
+    public enum RSA {
+        public enum Signing {}
+    }
+}
+
+extension Insecure.RSA.Signing {
+    public struct PublicKey: Equatable, Hashable {
+        // PublicExponent e
+        public let publicExponent: BigUInt
+        
+        // Modulus n
+        public let modulus: BigUInt
+        
+        public var rawRepresentation: Data {
+            publicExponent.serialize() + modulus.serialize()
+        }
+        
+        enum PubkeyParseError: Error {
+            case invalidInitialSequence, invalidAlgorithmIdentifier, invalidSubjectPubkey, forbiddenTrailingData, invalidRSAPubkey
+        }
+        
+        public init(publicExponent: BigUInt, modulus: BigUInt) {
+            self.publicExponent = publicExponent
+            self.modulus = modulus
+        }
+        
+        public func encrypt<D: DataProtocol>(for message: D) throws -> EncrytpedMessage {
+            let message = BigUInt(Data(message))
+            
+            guard message > .zero && message <= modulus - 1 else {
+                throw RSAError.messageRepresentativeOutOfRange
+            }
+            
+            let result = message.power(publicExponent, modulus: modulus)
+            return EncrytpedMessage(rawRepresentation: result.serialize())
+        }
+        
+        public func isValidSignature<D: DataProtocol>(_ signature: Signature, for digest: D) -> Bool {
+            let signature = BigUInt(signature.rawRepresentation)
+            
+            guard signature > .zero && signature <= modulus - 1 else {
+                return false
+            }
+            
+            let m = signature.power(publicExponent, modulus: modulus)
+            return m.serialize() == Data(digest)
+        }
+    }
+    
+    public struct EncrytpedMessage: ContiguousBytes {
+        public let rawRepresentation: Data
+        
+        public init<D>(rawRepresentation: D) where D : DataProtocol {
+            self.rawRepresentation = Data(rawRepresentation)
+        }
+        
+        public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            try rawRepresentation.withUnsafeBytes(body)
+        }
+    }
+    
+    public struct Signature: ContiguousBytes {
+        public let rawRepresentation: Data
+        
+        public init<D>(rawRepresentation: D) where D : DataProtocol {
+            self.rawRepresentation = Data(rawRepresentation)
+        }
+        
+        public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            try rawRepresentation.withUnsafeBytes(body)
+        }
+    }
+    
+    public struct PrivateKey {
+        public enum Storage {
+            case privateExponent(d: BigUInt, n: BigUInt)
+            // TODO: Quintuple
+        }
+        
+        // Private Exponent
+        public let storage: Storage
+        
+        // Public Exponent e
+        public let publicKey: PublicKey
+        
+        public init(privateExponent: BigUInt, publicExponent: BigUInt, modulus: BigUInt) {
+            self.storage = .privateExponent(d: privateExponent, n: modulus)
+            self.publicKey = PublicKey(publicExponent: publicExponent, modulus: modulus)
+        }
+        
+        public init(bits: Int = 2047, publicExponent e: BigUInt = 65537) {
+            let p = BigUInt.randomPrime(bits: bits)
+            let q = BigUInt.randomPrime(bits: bits)
+            
+            let n = p * q // modulus
+            let phi = (p - 1) * (q - 1)
+            let d = e.inverse(phi)!
+            self.storage = .privateExponent(d: d, n: n)
+               
+            self.publicKey = PublicKey(
+                publicExponent: e,
+                modulus: n
+            )
+        }
+        
+        public func signature<D: DataProtocol>(for message: D) throws -> Signature {
+            switch storage {
+            case .privateExponent(_, let n):
+                let message = try Self.encodePKCS1SHA1(message, length: (n.bitWidth + 7) / 8)
+                
+                let result = self.signature(for: BigUInt(Data(message)))
+                return Signature(rawRepresentation: result.serialize())
+            }
+        }
+        
+        private static func encodePKCS1SHA1<D: DataProtocol>(_ data: D, length: Int) throws -> Data {
+            /*
+             * This is the magic ASN.1/DER prefix that goes in the decoded
+             * signature, between the string of FFs and the actual SHA-1
+             * hash value. The meaning of it is:
+             *
+             * 00 -- this marks the end of the FFs; not part of the ASN.1
+             * bit itself
+             *
+             * 30 21 -- a constructed SEQUENCE of length 0x21
+             *    30 09 -- a constructed sub-SEQUENCE of length 9
+             *       06 05 -- an object identifier, length 5
+             *          2B 0E 03 02 1A -- object id { 1 3 14 3 2 26 }
+             *                            (the 1,3 comes from 0x2B = 43 = 40*1+3)
+             *       05 00 -- NULL
+             *    04 14 -- a primitive OCTET STRING of length 0x14
+             *       [0x14 bytes of hash data follows]
+             *
+             * The object id in the middle there is listed as `id-sha1' in
+             * ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1d2.asn
+             * (the ASN module for PKCS #1) and its expanded form is as
+             * follows:
+             *
+             * id-sha1                OBJECT IDENTIFIER ::= {
+             *    iso(1) identified-organization(3) oiw(14) secsig(3)
+             *    algorithms(2) 26 }
+             */
+            let prefix: [UInt8] = [
+                0x00, 0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2B,
+                0x0E, 0x03, 0x02, 0x1A, 0x05, 0x00, 0x04, 0x14,
+            ]
+            
+            let padding = length - prefix.count - 2 - Insecure.SHA1.Digest.byteCount
+            
+            var buffer = ByteBuffer()
+            buffer.writeInteger(0 as UInt8)
+            buffer.writeInteger(1 as UInt8)
+            for _ in 0..<padding {
+                buffer.writeInteger(0xff as UInt8)
+            }
+            buffer.writeBytes(prefix)
+            buffer.writeBytes(Insecure.SHA1.hash(data: data))
+            
+            return buffer.readData(length: buffer.readableBytes)!
+        }
+        
+        private func signature(for m: BigUInt) -> BigUInt {
+            switch storage {
+            case let .privateExponent(d, n):
+                return m.power(d, modulus: n)
+            }
+        }
+        
+        public func decrypt(_ signature: EncrytpedMessage) throws -> Data {
+            let signature = BigUInt(signature.rawRepresentation)
+            
+            switch storage {
+            case let .privateExponent(privateExponent, modulus):
+                guard signature >= .zero && signature <= privateExponent else {
+                    throw RSAError.ciphertextRepresentativeOutOfRange
+                }
+                
+                return signature.power(privateExponent, modulus: modulus).serialize()
+            }
+        }
+    }
+}
+
+public struct RSAError: Error {
+    let message: String
+    
+    static let messageRepresentativeOutOfRange = RSAError(message: "message representative out of range")
+    static let ciphertextRepresentativeOutOfRange = RSAError(message: "ciphertext representative out of range")
+    static let signatureRepresentativeOutOfRange = RSAError(message: "signature representative out of range")
+    static let invalidPem = RSAError(message: "invalid PEM")
+    static let pkcs1Error = RSAError(message: "PKCS1Error")
+}
+
+extension BigUInt {
+    public static func randomPrime(bits: Int) -> BigUInt {
+        while true {
+            var privateExponent = BigUInt.randomInteger(withExactWidth: bits)
+            privateExponent |= 1
+            
+            if privateExponent.isPrime() {
+                return privateExponent
+            }
+        }
+    }
+    
+    fileprivate init(boringSSL bignum: UnsafeMutablePointer<BIGNUM>) {
+        var data = [UInt8](repeating: 0, count: Int(CCryptoBoringSSL_BN_num_bytes(bignum)))
+        CCryptoBoringSSL_BN_bn2bin(bignum, &data)
+        self.init(Data(data))
+    }
+}
+
+extension BigUInt {
+    public static let diffieHellmanGroup14 = BigUInt(Data([
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xC9, 0x0F, 0xDA, 0xA2, 0x21, 0x68, 0xC2, 0x34,
+        0xC4, 0xC6, 0x62, 0x8B, 0x80, 0xDC, 0x1C, 0xD1,
+        0x29, 0x02, 0x4E, 0x08, 0x8A, 0x67, 0xCC, 0x74,
+        0x02, 0x0B, 0xBE, 0xA6, 0x3B, 0x13, 0x9B, 0x22,
+        0x51, 0x4A, 0x08, 0x79, 0x8E, 0x34, 0x04, 0xDD,
+        0xEF, 0x95, 0x19, 0xB3, 0xCD, 0x3A, 0x43, 0x1B,
+        0x30, 0x2B, 0x0A, 0x6D, 0xF2, 0x5F, 0x14, 0x37,
+        0x4F, 0xE1, 0x35, 0x6D, 0x6D, 0x51, 0xC2, 0x45,
+        0xE4, 0x85, 0xB5, 0x76, 0x62, 0x5E, 0x7E, 0xC6,
+        0xF4, 0x4C, 0x42, 0xE9, 0xA6, 0x37, 0xED, 0x6B,
+        0x0B, 0xFF, 0x5C, 0xB6, 0xF4, 0x06, 0xB7, 0xED,
+        0xEE, 0x38, 0x6B, 0xFB, 0x5A, 0x89, 0x9F, 0xA5,
+        0xAE, 0x9F, 0x24, 0x11, 0x7C, 0x4B, 0x1F, 0xE6,
+        0x49, 0x28, 0x66, 0x51, 0xEC, 0xE4, 0x5B, 0x3D,
+        0xC2, 0x00, 0x7C, 0xB8, 0xA1, 0x63, 0xBF, 0x05,
+        0x98, 0xDA, 0x48, 0x36, 0x1C, 0x55, 0xD3, 0x9A,
+        0x69, 0x16, 0x3F, 0xA8, 0xFD, 0x24, 0xCF, 0x5F,
+        0x83, 0x65, 0x5D, 0x23, 0xDC, 0xA3, 0xAD, 0x96,
+        0x1C, 0x62, 0xF3, 0x56, 0x20, 0x85, 0x52, 0xBB,
+        0x9E, 0xD5, 0x29, 0x07, 0x70, 0x96, 0x96, 0x6D,
+        0x67, 0x0C, 0x35, 0x4E, 0x4A, 0xBC, 0x98, 0x04,
+        0xF1, 0x74, 0x6C, 0x08, 0xCA, 0x18, 0x21, 0x7C,
+        0x32, 0x90, 0x5E, 0x46, 0x2E, 0x36, 0xCE, 0x3B,
+        0xE3, 0x9E, 0x77, 0x2C, 0x18, 0x0E, 0x86, 0x03,
+        0x9B, 0x27, 0x83, 0xA2, 0xEC, 0x07, 0xA2, 0x8F,
+        0xB5, 0xC5, 0x5D, 0xF0, 0x6F, 0x4C, 0x52, 0xC9,
+        0xDE, 0x2B, 0xCB, 0xF6, 0x95, 0x58, 0x17, 0x18,
+        0x39, 0x95, 0x49, 0x7C, 0xEA, 0x95, 0x6A, 0xE5,
+        0x15, 0xD2, 0x26, 0x18, 0x98, 0xFA, 0x05, 0x10,
+        0x15, 0x72, 0x8E, 0x5A, 0x8A, 0xAC, 0xAA, 0x68,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    ] as [UInt8]))
+}

--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -89,6 +89,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
 
         switch data.type {
         case .channel:
+            print(bytes.getString(at: 0, length: bytes.readableBytes))
             // Channel data is forwarded on, the pipe channel will handle it.
             context.fireChannelRead(self.wrapInboundOut(bytes))
             return

--- a/Sources/NIOSSHClient/InteractivePasswordPromptDelegate.swift
+++ b/Sources/NIOSSHClient/InteractivePasswordPromptDelegate.swift
@@ -15,20 +15,16 @@
 import Dispatch
 import Foundation
 import NIO
+import Crypto
+import CCryptoBoringSSL
 import NIOSSH
 
 /// A client user auth delegate that provides an interactive prompt for password-based user auth.
 final class InteractivePasswordPromptDelegate: NIOSSHClientUserAuthenticationDelegate {
     private let queue: DispatchQueue
 
-    private var username: String?
-
-    private var password: String?
-
-    init(username: String?, password: String?) {
+    init() {
         self.queue = DispatchQueue(label: "io.swiftnio.ssh.InteractivePasswordPromptDelegate")
-        self.username = username
-        self.password = password
     }
 
     func nextAuthenticationType(availableMethods: NIOSSHAvailableUserAuthenticationMethods, nextChallengePromise: EventLoopPromise<NIOSSHUserAuthenticationOffer?>) {
@@ -39,17 +35,7 @@ final class InteractivePasswordPromptDelegate: NIOSSHClientUserAuthenticationDel
         }
 
         self.queue.async {
-            if self.username == nil {
-                print("Username: ", terminator: "")
-                self.username = readLine() ?? ""
-            }
-
-            if self.password == nil {
-                print("Password: ", terminator: "")
-                self.password = readLine() ?? ""
-            }
-
-            nextChallengePromise.succeed(NIOSSHUserAuthenticationOffer(username: self.username!, serviceName: "", offer: .password(.init(password: self.password!))))
+            nextChallengePromise.succeed(NIOSSHUserAuthenticationOffer(username: "joannis", serviceName: "", offer: .privateKey(NIOSSHUserAuthenticationOffer.Offer.PrivateKey(privateKey: .init(rsa: .init())))))
         }
     }
 }

--- a/Sources/NIOSSHClient/main.swift
+++ b/Sources/NIOSSHClient/main.swift
@@ -38,9 +38,6 @@ final class AcceptAllHostKeysDelegate: NIOSSHClientServerAuthenticationDelegate 
     }
 }
 
-let parser = SimpleCLIParser()
-let parseResult = parser.parse()
-
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 defer {
     try! group.syncShutdownGracefully()
@@ -48,12 +45,12 @@ defer {
 
 let bootstrap = ClientBootstrap(group: group)
     .channelInitializer { channel in
-        channel.pipeline.addHandlers([NIOSSHHandler(role: .client(.init(userAuthDelegate: InteractivePasswordPromptDelegate(username: parseResult.user, password: parseResult.password), serverAuthDelegate: AcceptAllHostKeysDelegate())), allocator: channel.allocator, inboundChildChannelInitializer: nil), ErrorHandler()])
+        channel.pipeline.addHandlers([NIOSSHHandler(role: .client(.init(userAuthDelegate: InteractivePasswordPromptDelegate(), serverAuthDelegate: AcceptAllHostKeysDelegate())), allocator: channel.allocator, inboundChildChannelInitializer: nil), ErrorHandler()])
     }
     .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
     .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
 
-let channel = try bootstrap.connect(host: parseResult.host, port: parseResult.port).wait()
+let channel = try bootstrap.connect(host: "orlandos.nl", port: 22).wait()
 
 // Let's try creating a child channel.
 let exitStatusPromise = channel.eventLoop.makePromise(of: Int.self)
@@ -63,7 +60,7 @@ let childChannel: Channel = try! channel.pipeline.handler(type: NIOSSHHandler.se
         guard channelType == .session else {
             return channel.eventLoop.makeFailedFuture(SSHClientError.invalidChannelType)
         }
-        return childChannel.pipeline.addHandlers([ExampleExecHandler(command: parseResult.commandString, completePromise: exitStatusPromise), ErrorHandler()])
+        return childChannel.pipeline.addHandlers([ExampleExecHandler(command: "ls -la", completePromise: exitStatusPromise), ErrorHandler()])
     }
     return promise.futureResult
 }.wait()


### PR DESCRIPTION
Notes:

I've implemented RSA in a separate module within this repo, to be split out of this repository before merging. It serves as an example implementation for this PR.

I believe there are a couple of API design choices, like protocol names, that should be improved. I'm happy to take any feedback, of course.