### PR TITLE
Adds emittion of user authentication success event.

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -16,6 +16,11 @@ protocol AcceptsUserAuthMessages {
     var userAuthStateMachine: UserAuthenticationStateMachine { get set }
 }
 
+/// This event indicates that server accepted our response to authentication challenge. SSH session can be considered active after that.
+public struct UserAuthSuccessEvent: Hashable {
+    public init() {}
+}
+
 extension AcceptsUserAuthMessages {
     mutating func receiveServiceRequest(_ message: SSHMessage.ServiceRequestMessage) throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {
         let result = try self.userAuthStateMachine.receiveServiceRequest(message)
@@ -52,7 +57,7 @@ extension AcceptsUserAuthMessages {
     /// If this method completes without throwing, user auth has completed.
     mutating func receiveUserAuthSuccess() throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {
         try self.userAuthStateMachine.receiveUserAuthSuccess()
-        return .noMessage
+        return .event(UserAuthSuccessEvent())
     }
 
     mutating func receiveUserAuthFailure(_ message: SSHMessage.UserAuthFailureMessage) throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {

--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -1033,6 +1033,7 @@ extension SSHConnectionStateMachine {
         case globalRequest(SSHMessage.GlobalRequestMessage)
         case disconnect
         case noMessage
+        case event(Any)
 
         enum GlobalRequestResponse {
             case success(SSHMessage.RequestSuccessMessage)

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -216,6 +216,8 @@ extension NIOSSHHandler: ChannelDuplexHandler {
         case .disconnect:
             // Welp, we immediately have to close.
             context.close(promise: nil)
+        case .event(let event):
+            context.fireUserInboundEventTriggered(event)
         }
     }
 }

--- a/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
@@ -94,6 +94,8 @@ final class SSHConnectionStateMachineTests: XCTestCase {
                     }
                 case .some(.forwardToMultiplexer), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect):
                     fatalError("Currently unsupported")
+                case .some(.event):
+                    ()
                 }
             }
 
@@ -120,7 +122,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
                             }
                         }
                     }
-                case .some(.forwardToMultiplexer), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect):
+                case .some(.forwardToMultiplexer), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event):
                     fatalError("Currently unsupported")
                 }
             }
@@ -144,7 +146,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         switch result {
         case .some(.forwardToMultiplexer(let forwardedMessage)):
             XCTAssertEqual(forwardedMessage, message)
-        case .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .none:
+        case .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event), .none:
             XCTFail("Unexpected result: \(String(describing: result))")
         }
     }
@@ -169,7 +171,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         case .some(.disconnect):
             // Good
             break
-        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .none:
+        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.event), .none:
             XCTFail("Unexpected result: \(String(describing: result))")
         }
     }
@@ -186,7 +188,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         case .some(.globalRequest(let receivedMessage)):
             // Good
             XCTAssertEqual(.globalRequest(receivedMessage), message)
-        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequestResponse), .some(.disconnect), .none:
+        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequestResponse), .some(.disconnect), .some(.event), .none:
             XCTFail("Unexpected result: \(String(describing: result))")
         }
     }
@@ -203,7 +205,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         case .some(.globalRequestResponse(let response)):
             // Good
             return response
-        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.disconnect), .none:
+        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.disconnect), .some(.event), .none:
             XCTFail("Unexpected result: \(String(describing: result))")
             return nil
         }
@@ -221,7 +223,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         case .some(.noMessage):
             // Good
             break
-        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .none:
+        case .some(.forwardToMultiplexer), .some(.emitMessage), .some(.possibleFutureMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event), .none:
             XCTFail("Unexpected result: \(String(describing: result))")
         }
     }


### PR DESCRIPTION
Motivation:
Currently there is now way to wait for successful SSH session
establishment, the only way to continue is to try to create a child
channel. Given that most clients are expecting the session to be active
when both key exchange and user authenticaiton complete, I propose to
emit UserAuthSuccessEvent.  That way client can wait for that event or
fail if there is an error in the pipeline.

Modifications:
 - Adds UserAuthSuccessEvent event
 - Adds .event case to StateMachineInboundProcessResult
 - Adds emittion of event if StateMachineInboundProcessResult is .event
 - Adds two tests

Result:
Closes #39