### PR TITLE
Add support from synchronous options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "NIOSSH", targets: ["NIOSSH"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.21.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Motivation:

NIO 2.27.0 added a customisation point to `Channel` to allow options to
be fetched synchronously if the caller is on the appropriate event loop.

Modifications:

- Add synchronous options to SSHChildChannel
- Promote event loop assertions to preconditions

Result:

Callers can fetch channel options synchronously on 'SSHChildChannel's.