### PR TITLE
fixes compilation warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "NIOSSH", targets: ["NIOSSH"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -544,7 +544,7 @@ extension SSHChildChannel: Channel, ChannelCore {
         self.notifyChannelInactive()
 
         self.eventLoop.execute {
-            self.removeHandlers(channel: self)
+            self.removeHandlers(pipeline: self.pipeline)
             self.closePromise.succeed(())
             self.multiplexer.childChannelClosed(channelID: self.state.localChannelIdentifier)
         }
@@ -581,7 +581,7 @@ extension SSHChildChannel: Channel, ChannelCore {
         }
 
         self.eventLoop.execute {
-            self.removeHandlers(channel: self)
+            self.removeHandlers(pipeline: self.pipeline)
             self.closePromise.fail(error)
             self.multiplexer.childChannelErrored(channelID: self.state.localChannelIdentifier, expectClose: !self.state.isClosed)
         }


### PR DESCRIPTION
Motivation:
Method Channel.removeHandlers(channel: Channel) was deprecated in 2.32,
we should use recommended method instead.

Modifications:
 - Bump swift-nio version to 2.32 to ensue that new methods are
   available
 - Use new method to remove all handlers