### PR TITLE
Fix doc generation and jazzy version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 # ruby and jazzy for docs generation, only on focal
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
 RUN if [ "${ubuntu_version}" == "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
- RUN if [ "${ubuntu_version}" == "focal" ] ; then  gem install jazzy; fi
+RUN if [ "${ubuntu_version}" == "focal" ] ; then  gem install jazzy; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,12 +16,10 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
 
-# ruby and jazzy for docs generation
+# ruby and jazzy for docs generation, only on focal
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
-# switch off gem docs building
-RUN echo "gem: --no-document" > ~/.gemrc
-# jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy; fi
+RUN if [ "${ubuntu_version}" == "focal" ] ; then echo "gem: --no-document" > ~/.gemrc; fi
+ RUN if [ "${ubuntu_version}" == "focal" ] ; then  gem install jazzy; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -40,7 +40,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
   mkdir -p "$root_path/.build/sourcekitten"
   for module in "${modules[@]}"; do
     if [[ ! -f "$root_path/.build/sourcekitten/$module.json" ]]; then
-      "$source_kitten_path/sourcekitten" doc --spm-module $module > "$root_path/.build/sourcekitten/$module.json"
+      "$source_kitten_path/sourcekitten" doc --module-name $module > "$root_path/.build/sourcekitten/$module.json"
     fi
   done
 fi


### PR DESCRIPTION
Motivation:

The combination of Ruby and Jazzy are throwing up issues in CI on older
Ubuntu versions.

Modifications:

- Only install Jazzy on focal
- Fix doc generation script to use more recent source-kitten syntax

Results:

- CI doesn't complain
- Docs get built