### PR TITLE
Widen the pin on Crypto.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Motivation:

Crypto has a very minor breaking change that doesn't affect us, so we
can and should tolerate 1.x and 2.x.

Modifications:

- Widen the pin on Crypto

Result:

We get all the new Crypto goodness.