### PR TITLE
Fix crash sending window increment after close

### DIFF
--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -640,7 +640,8 @@ private extension SSHChildChannel {
     private func deliverSingleRead(_ data: PendingContent) {
         switch data {
         case .data(let data):
-            if let increment = self.windowManager.unbufferBytes(data.data.readableBytes) {
+            // We only futz with the window manager if the channel is not already closed.
+            if !self.didClose, let increment = self.windowManager.unbufferBytes(data.data.readableBytes) {
                 let update = SSHMessage.ChannelWindowAdjustMessage(recipientChannel: self.state.remoteChannelIdentifier!, bytesToAdd: UInt32(increment))
                 self.processOutboundMessage(.channelWindowAdjust(update), promise: nil)
             }

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/2017-20[12][890]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
+    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
 }
 
 command -v swiftformat >/dev/null 2>&1 || { echo >&2 "swiftformat needs to be installed but is not available in the path."; exit 1; }


### PR DESCRIPTION
Motivation:

When reads have yet to be delivered to a channel and we receive a
CHANNEL_CLOSE message, we forcibly deliver all of the reads. As part of
doing this, we process the window size changes and potentially send
window increment messages. These messages are invalid to send at this
time, and the state machine rightly forbids us from sending them, which
causes a crash.

Modifications:

- Change the code to only futz with the channel window if the channel is
  still open.

Result:

No crashing after channel close.