### PR TITLE
Feature/userauth banners

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -101,7 +101,7 @@ extension AcceptsUserAuthMessages {
         case .success:
             if let banner = banner {
                 // Send banner bundled with auth success to avoid leaking any information to unauthenticated clients.
-                // Note that this is by no means the only option
+                // Note that this is by no means the only option according to RFC 4252
                 return SSHMultiMessage(.userAuthBanner(.init(message: banner.message, languageTag: banner.languageTag)), .userAuthSuccess)
             }
 

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -19,9 +19,17 @@ protocol AcceptsUserAuthMessages {
 }
 
 /// This event indicates that server wants us to display the following message to the end user.
-public struct UserAuthBannerEvent: Hashable {
-    public let message: String
-    public let languageTag: String
+public struct NIOUserAuthBannerEvent: Hashable {
+    /// message to be displayed to end user
+    public var message: String
+
+    /// tag  identifying the language used for `message`, following RFC 3066
+    public var languageTag: String
+
+    public init(message: String, languageTag: String) {
+        self.message = message
+        self.languageTag = languageTag
+    }
 }
 
 /// This event indicates that server accepted our response to authentication challenge. SSH session can be considered active after that.
@@ -80,7 +88,7 @@ extension AcceptsUserAuthMessages {
 
     mutating func receiveUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage) throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {
       try self.userAuthStateMachine.receiveUserAuthBanner(message)
-      return .event(UserAuthBannerEvent(message: message.message, languageTag: message.languageTag))
+      return .event(NIOUserAuthBannerEvent(message: message.message, languageTag: message.languageTag))
     }
 
     private func transform(_ result: NIOSSHUserAuthenticationResponseMessage) -> SSHMultiMessage {

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -67,7 +67,7 @@ extension AcceptsUserAuthMessages {
                 banner = config.banner
             }
 
-            return .possibleFutureMessage(future.map({ Self.transform($0, banner: banner)}))
+            return .possibleFutureMessage(future.map { Self.transform($0, banner: banner) })
         } else {
             return .noMessage
         }
@@ -92,8 +92,8 @@ extension AcceptsUserAuthMessages {
     }
 
     mutating func receiveUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage) throws -> SSHConnectionStateMachine.StateMachineInboundProcessResult {
-      try self.userAuthStateMachine.receiveUserAuthBanner(message)
-      return .event(NIOUserAuthBannerEvent(message: message.message, languageTag: message.languageTag))
+        try self.userAuthStateMachine.receiveUserAuthBanner(message)
+        return .event(NIOUserAuthBannerEvent(message: message.message, languageTag: message.languageTag))
     }
 
     private static func transform(_ result: NIOSSHUserAuthenticationResponseMessage, banner: SSHServerConfiguration.UserAuthBanner? = nil) -> SSHMultiMessage {

--- a/Sources/NIOSSH/Connection State Machine/Operations/SendsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/SendsUserAuthMessages.swift
@@ -46,6 +46,11 @@ extension SendsUserAuthMessages {
         try self.serializer.serialize(message: .userAuthFailure(message), to: &buffer)
     }
 
+    mutating func writeUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage, into buffer: inout ByteBuffer) throws {
+        self.userAuthStateMachine.sendUserAuthBanner(message)
+        try self.serializer.serialize(message: .userAuthBanner(message), to: &buffer)
+    }
+
     mutating func writeUserAuthPKOK(_ message: SSHMessage.UserAuthPKOKMessage, into buffer: inout ByteBuffer) throws {
         self.userAuthStateMachine.sendUserAuthPKOK(message)
         try self.serializer.serialize(message: .userAuthPKOK(message), to: &buffer)

--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -318,9 +318,9 @@ struct SSHConnectionStateMachine {
                 return result
 
             case .userAuthBanner(let message):
-              let result = try state.receiveUserAuthBanner(message)
-              self.state = .userAuthentication(state)
-              return result
+                let result = try state.receiveUserAuthBanner(message)
+                self.state = .userAuthentication(state)
+                return result
 
             case .disconnect:
                 self.state = .receivedDisconnect(state.role)

--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -317,6 +317,11 @@ struct SSHConnectionStateMachine {
                 self.state = .userAuthentication(state)
                 return result
 
+            case .userAuthBanner(let message):
+              let result = try state.receiveUserAuthBanner(message)
+              self.state = .userAuthentication(state)
+              return result
+
             case .disconnect:
                 self.state = .receivedDisconnect(state.role)
                 return .disconnect
@@ -804,6 +809,10 @@ struct SSHConnectionStateMachine {
 
             case .serviceAccept(let message):
                 try state.writeServiceAccept(message, into: &buffer)
+                self.state = .userAuthentication(state)
+
+            case .userAuthBanner(let message):
+                try state.writeUserAuthBanner(message, into: &buffer)
                 self.state = .userAuthentication(state)
 
             case .userAuthRequest(let message):

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -170,15 +170,15 @@ extension SSHMessage {
         static let id: UInt8 = 52
     }
 
-  struct UserAuthBannerMessage: Equatable {
-      // SSH_MSG_USERAUTH_BANNER
-      static let id: UInt8 = 53
+    struct UserAuthBannerMessage: Equatable {
+        // SSH_MSG_USERAUTH_BANNER
+        static let id: UInt8 = 53
 
-      /// message to display to user in client, encoded as ISO-10646 UTF-8 following RFC 3629
-      var message: String
+        /// message to display to user in client, encoded as ISO-10646 UTF-8 following RFC 3629
+        var message: String
 
-      /// tag identifying language of banner, following RFC 3066
-      var languageTag: String
+        /// tag identifying language of banner, following RFC 3066
+        var languageTag: String
     }
 
     struct UserAuthPKOKMessage: Equatable {
@@ -737,7 +737,7 @@ extension ByteBuffer {
     mutating func readUserAuthBannerMessage() -> SSHMessage.UserAuthBannerMessage? {
         self.rewindReaderOnNil { `self` in
             guard let message = self.readSSHStringAsString(),
-                  let languageTag = self.readSSHStringAsString()
+                let languageTag = self.readSSHStringAsString()
             else {
                 return nil
             }

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -432,10 +432,10 @@ extension ByteBuffer {
             case SSHMessage.UserAuthSuccessMessage.id:
                 return .userAuthSuccess
             case SSHMessage.UserAuthBannerMessage.id:
-              guard let message = self.readUserAuthBannerMessage()  else {
-                return nil
-              }
-              return .userAuthBanner(message)
+                guard let message = self.readUserAuthBannerMessage() else {
+                    return nil
+                }
+                return .userAuthBanner(message)
             case SSHMessage.UserAuthPKOKMessage.id:
                 guard let message = try self.readUserAuthPKOKMessage() else {
                     return nil
@@ -735,15 +735,15 @@ extension ByteBuffer {
     }
 
     mutating func readUserAuthBannerMessage() -> SSHMessage.UserAuthBannerMessage? {
-      self.rewindReaderOnNil { `self` in
-        guard let message = self.readSSHStringAsString(),
-              let languageTag = self.readSSHStringAsString()
-        else {
-          return nil
-        }
+        self.rewindReaderOnNil { `self` in
+            guard let message = self.readSSHStringAsString(),
+                  let languageTag = self.readSSHStringAsString()
+            else {
+                return nil
+            }
 
-        return SSHMessage.UserAuthBannerMessage(message: message, languageTag: languageTag)
-      }
+            return SSHMessage.UserAuthBannerMessage(message: message, languageTag: languageTag)
+        }
     }
 
     mutating func readUserAuthPKOKMessage() throws -> SSHMessage.UserAuthPKOKMessage? {
@@ -1329,10 +1329,10 @@ extension ByteBuffer {
     }
 
     mutating func writeUserAuthBannerMessage(_ message: SSHMessage.UserAuthBannerMessage) -> Int {
-      var writtenBytes = 0
-      writtenBytes += self.writeSSHString(message.message.utf8)
-      writtenBytes += self.writeSSHString(message.languageTag.utf8)
-      return writtenBytes
+        var writtenBytes = 0
+        writtenBytes += self.writeSSHString(message.message.utf8)
+        writtenBytes += self.writeSSHString(message.languageTag.utf8)
+        return writtenBytes
     }
 
     mutating func writeUserAuthPKOKMessage(_ message: SSHMessage.UserAuthPKOKMessage) -> Int {

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -171,12 +171,13 @@ extension SSHMessage {
     }
 
   struct UserAuthBannerMessage: Equatable {
+      // SSH_MSG_USERAUTH_BANNER
       static let id: UInt8 = 53
 
-      /// ISO-10646 UTF-8 encoding [RFC3629]
+      /// message to display to user in client, encoded as ISO-10646 UTF-8 following RFC 3629
       var message: String
 
-      /// language tag [RFC3066]
+      /// tag identifying language of banner, following RFC 3066
       var languageTag: String
     }
 
@@ -1326,7 +1327,7 @@ extension ByteBuffer {
         writtenBytes += self.writeSSHBoolean(message.partialSuccess)
         return writtenBytes
     }
-  
+
     mutating func writeUserAuthBannerMessage(_ message: SSHMessage.UserAuthBannerMessage) -> Int {
       var writtenBytes = 0
       writtenBytes += self.writeSSHString(message.message.utf8)

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -36,6 +36,7 @@ enum SSHMessage: Equatable {
     case userAuthRequest(UserAuthRequestMessage)
     case userAuthFailure(UserAuthFailureMessage)
     case userAuthSuccess
+    case userAuthBanner(UserAuthBannerMessage)
     case userAuthPKOK(UserAuthPKOKMessage)
     case globalRequest(GlobalRequestMessage)
     case requestSuccess(RequestSuccessMessage)
@@ -167,6 +168,16 @@ extension SSHMessage {
 
     enum UserAuthSuccessMessage {
         static let id: UInt8 = 52
+    }
+
+  struct UserAuthBannerMessage: Equatable {
+      static let id: UInt8 = 53
+
+      /// ISO-10646 UTF-8 encoding [RFC3629]
+      var message: String
+
+      /// language tag [RFC3066]
+      var languageTag: String
     }
 
     struct UserAuthPKOKMessage: Equatable {
@@ -419,6 +430,11 @@ extension ByteBuffer {
                 return .userAuthFailure(message)
             case SSHMessage.UserAuthSuccessMessage.id:
                 return .userAuthSuccess
+            case SSHMessage.UserAuthBannerMessage.id:
+              guard let message = self.readUserAuthBannerMessage()  else {
+                return nil
+              }
+              return .userAuthBanner(message)
             case SSHMessage.UserAuthPKOKMessage.id:
                 guard let message = try self.readUserAuthPKOKMessage() else {
                     return nil
@@ -715,6 +731,18 @@ extension ByteBuffer {
 
             return SSHMessage.UserAuthFailureMessage(authentications: authentications, partialSuccess: partialSuccess)
         }
+    }
+
+    mutating func readUserAuthBannerMessage() -> SSHMessage.UserAuthBannerMessage? {
+      self.rewindReaderOnNil { `self` in
+        guard let message = self.readSSHStringAsString(),
+              let languageTag = self.readSSHStringAsString()
+        else {
+          return nil
+        }
+
+        return SSHMessage.UserAuthBannerMessage(message: message, languageTag: languageTag)
+      }
     }
 
     mutating func readUserAuthPKOKMessage() throws -> SSHMessage.UserAuthPKOKMessage? {
@@ -1134,6 +1162,9 @@ extension ByteBuffer {
             writtenBytes += self.writeUserAuthFailureMessage(message)
         case .userAuthSuccess:
             writtenBytes += self.writeInteger(52 as UInt8)
+        case .userAuthBanner(let message):
+            writtenBytes += self.writeInteger(SSHMessage.UserAuthBannerMessage.id)
+            writtenBytes += self.writeUserAuthBannerMessage(message)
         case .userAuthPKOK(let message):
             writtenBytes += self.writeInteger(SSHMessage.UserAuthPKOKMessage.id)
             writtenBytes += self.writeUserAuthPKOKMessage(message)
@@ -1294,6 +1325,13 @@ extension ByteBuffer {
         writtenBytes += self.writeAlgorithms(message.authentications)
         writtenBytes += self.writeSSHBoolean(message.partialSuccess)
         return writtenBytes
+    }
+  
+    mutating func writeUserAuthBannerMessage(_ message: SSHMessage.UserAuthBannerMessage) -> Int {
+      var writtenBytes = 0
+      writtenBytes += self.writeSSHString(message.message.utf8)
+      writtenBytes += self.writeSSHString(message.languageTag.utf8)
+      return writtenBytes
     }
 
     mutating func writeUserAuthPKOKMessage(_ message: SSHMessage.UserAuthPKOKMessage) -> Int {

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -23,9 +23,30 @@ public struct SSHServerConfiguration {
     /// The host keys for this server.
     public var hostKeys: [NIOSSHPrivateKey]
 
-    public init(hostKeys: [NIOSSHPrivateKey], userAuthDelegate: NIOSSHServerUserAuthenticationDelegate, globalRequestDelegate: GlobalRequestDelegate? = nil) {
+    /// The ssh banner to display to clients upon authentication
+    public var banner: UserAuthBanner?
+
+    public init(hostKeys: [NIOSSHPrivateKey], userAuthDelegate: NIOSSHServerUserAuthenticationDelegate, globalRequestDelegate: GlobalRequestDelegate? = nil, banner: UserAuthBanner? = nil) {
         self.hostKeys = hostKeys
         self.userAuthDelegate = userAuthDelegate
         self.globalRequestDelegate = globalRequestDelegate ?? DefaultGlobalRequestDelegate()
+        self.banner = banner
+    }
+}
+
+// MARK: - UserAuthBanner
+public extension SSHServerConfiguration {
+    /**
+     Server sends `UserAuthBanner` to client some time during authentication.
+     Client is obligated to display this banner to the end user, unless explicitely told
+     to ignore banners.
+     */
+    struct UserAuthBanner {
+        /// The message to display. Note that control characters contained in message
+        /// might be filtered in  accordance with the SSH specification.
+        let message: String
+
+        /// Language tag describing the language used for message. Must obey RFC 3066
+        let languageTag: String
     }
 }

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -32,6 +32,10 @@ public struct SSHServerConfiguration {
         self.globalRequestDelegate = globalRequestDelegate ?? DefaultGlobalRequestDelegate()
         self.banner = banner
     }
+
+    public init(hostKeys: [NIOSSHPrivateKey], userAuthDelegate: NIOSSHServerUserAuthenticationDelegate, globalRequestDelegate: GlobalRequestDelegate? = nil) {
+        self.init(hostKeys: hostKeys, userAuthDelegate: userAuthDelegate, globalRequestDelegate: globalRequestDelegate, banner: nil)
+    }
 }
 
 // MARK: - UserAuthBanner

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -39,18 +39,26 @@ public struct SSHServerConfiguration {
 }
 
 // MARK: - UserAuthBanner
-public extension SSHServerConfiguration {
+extension SSHServerConfiguration {
     /**
      Server sends `UserAuthBanner` to client some time during authentication.
      Client is obligated to display this banner to the end user, unless explicitely told
      to ignore banners.
      */
-    struct UserAuthBanner {
-        /// The message to display. Note that control characters contained in message
-        /// might be filtered in  accordance with the SSH specification.
-        let message: String
+    public struct UserAuthBanner {
+        /**
+         The message to be displayed by client to end user during authentication.
+         Note that control characters contained in message might be filtered by
+         client in accordance with RFC 4252.
+        */
+        public var message: String
 
-        /// Language tag describing the language used for message. Must obey RFC 3066
-        let languageTag: String
+        /// Tag describing the language used for message. Must obey RFC 3066
+        public var languageTag: String
+
+        public init(message: String, languageTag: String) {
+            self.message = message
+            self.languageTag = languageTag
+        }
     }
 }

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -39,6 +39,7 @@ public struct SSHServerConfiguration {
 }
 
 // MARK: - UserAuthBanner
+
 extension SSHServerConfiguration {
     /**
      Server sends `UserAuthBanner` to client some time during authentication.

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -50,7 +50,7 @@ extension SSHServerConfiguration {
          The message to be displayed by client to end user during authentication.
          Note that control characters contained in message might be filtered by
          client in accordance with RFC 4252.
-        */
+         */
         public var message: String
 
         /// Tag describing the language used for message. Must obey RFC 3066

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
@@ -187,7 +187,7 @@ extension UserAuthenticationStateMachine {
         }
     }
 
-    mutating func receiveUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage) throws {
+    mutating func receiveUserAuthBanner(_: SSHMessage.UserAuthBannerMessage) throws {
         switch (self.delegate, self.state) {
         case (.client, .idle), (.client, .authenticationSucceeded):
             // Server sent a user auth success but we didn't ask them to!

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
@@ -188,7 +188,17 @@ extension UserAuthenticationStateMachine {
     }
 
     mutating func receiveUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage) throws {
-      // TODO: implement validation
+        switch (self.delegate, self.state) {
+        case (.client, .idle), (.client, .authenticationSucceeded):
+            // Server sent a user auth success but we didn't ask them to!
+            throw NIOSSHError.protocolViolation(protocolName: Self.protocolName, violation: "server sent user auth banner at the wrong time")
+        case (.server, _):
+            // Servers may never receive user auth banner messages.
+            throw NIOSSHError.protocolViolation(protocolName: Self.protocolName, violation: "client sent user auth banner")
+        default:
+            // In all other instances, receiving user auth banner is legal and must be dealt with by client
+            return
+        }
     }
 }
 

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
@@ -186,6 +186,10 @@ extension UserAuthenticationStateMachine {
             throw NIOSSHError.protocolViolation(protocolName: Self.protocolName, violation: "client sent user auth failure")
         }
     }
+
+    mutating func receiveUserAuthBanner(_ message: SSHMessage.UserAuthBannerMessage) throws {
+      // TODO: implement validation
+    }
 }
 
 // MARK: Sending Messages
@@ -273,6 +277,28 @@ extension UserAuthenticationStateMachine {
 
     mutating func sendUserAuthFailure(_: SSHMessage.UserAuthFailureMessage) {
         self.sendUserAuthResponseMessage(success: false)
+    }
+
+    mutating func sendUserAuthBanner(_: SSHMessage.UserAuthBannerMessage) {
+        /*
+         Relevant passage from RFC 4252:
+
+         The SSH server may send an SSH_MSG_USERAUTH_BANNER message at any
+         time after this authentication protocol starts and before
+         authentication is successful.  This message contains text to be
+         displayed to the client user before authentication is attempted.  The
+         format is as follows:
+         */
+        switch (self.delegate, self.state) {
+        case (.server, .idle):
+            preconditionFailure("Banner sent before authentication protocol start")
+        case (.server, .authenticationSucceeded):
+            preconditionFailure("Banner sent after authentication suceeded")
+        case (.server, _):
+            break
+        case (.client, _):
+            preconditionFailure("Clients never send auth responses")
+        }
     }
 
     private mutating func sendUserAuthResponseMessage(success: Bool) {

--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -656,7 +656,7 @@ class EndToEndTests: XCTestCase {
                 guard let promise = self.promise else { return }
                 self.promise = nil
 
-                if event is UserAuthBannerEvent {
+                if event is NIOUserAuthBannerEvent {
                     promise.fail(HandshakeFailure.missingBanner)
                 } else if event is UserAuthSuccessEvent {
                     promise.succeed(())
@@ -700,7 +700,7 @@ class EndToEndTests: XCTestCase {
                 guard let promise = self.promise else { return }
                 self.promise = nil
 
-                if let event = event as? UserAuthBannerEvent {
+                if let event = event as? NIOUserAuthBannerEvent {
                     promise.succeed((event.message, event.languageTag))
                 } else if event is UserAuthSuccessEvent {
                     promise.fail(HandshakeFailure.missingBanner)

--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -83,7 +83,7 @@ class BackToBackEmbeddedChannel {
         let clientHandler = NIOSSHHandler(role: .client(.init(userAuthDelegate: harness.clientAuthDelegate, serverAuthDelegate: harness.clientServerAuthDelegate, globalRequestDelegate: harness.clientGlobalRequestDelegate)),
                                           allocator: self.client.allocator,
                                           inboundChildChannelInitializer: nil)
-        let serverHandler = NIOSSHHandler(role: .server(.init(hostKeys: harness.serverHostKeys, userAuthDelegate: harness.serverAuthDelegate, globalRequestDelegate: harness.serverGlobalRequestDelegate)),
+        let serverHandler = NIOSSHHandler(role: .server(.init(hostKeys: harness.serverHostKeys, userAuthDelegate: harness.serverAuthDelegate, globalRequestDelegate: harness.serverGlobalRequestDelegate, banner: harness.serverAuthBanner)),
                                           allocator: self.server.allocator) { channel, _ in
             self.activeServerChannels.append(channel)
             channel.closeFuture.whenComplete { _ in self.activeServerChannels.removeAll(where: { $0 === channel }) }
@@ -129,6 +129,8 @@ struct TestHarness {
     var serverGlobalRequestDelegate: GlobalRequestDelegate?
 
     var serverHostKeys: [NIOSSHPrivateKey] = [.init(ed25519Key: .init())]
+
+    var serverAuthBanner: SSHServerConfiguration.UserAuthBanner? = nil
 }
 
 final class UserEventExpecter: ChannelInboundHandler {
@@ -638,6 +640,94 @@ class EndToEndTests: XCTestCase {
         XCTAssertNoThrow(try self.channel.interactInMemory())
 
         XCTAssertNoThrow(try promise.futureResult.wait())
+    }
+
+    func testServerDoesNotSendBanner() throws {
+        class ClientHandshakeHandler: ChannelInboundHandler {
+            typealias InboundIn = Any
+
+            var promise: EventLoopPromise<Void>?
+
+            init(promise: EventLoopPromise<Void>) {
+                self.promise = promise
+            }
+
+            func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+                guard let promise = self.promise else { return }
+                self.promise = nil
+
+                if event is UserAuthBannerEvent {
+                    promise.fail(HandshakeFailure.missingBanner)
+                } else if event is UserAuthSuccessEvent {
+                    promise.succeed(())
+                }
+            }
+
+            enum HandshakeFailure: Error {
+                case missingBanner
+            }
+        }
+
+        let promise = self.channel.client.eventLoop.makePromise(of: Void.self)
+        let handshaker = ClientHandshakeHandler(promise: promise)
+
+        var harness = TestHarness()
+        harness.serverAuthBanner = nil
+
+        // Set up the connection, validate all is well.
+        XCTAssertNoThrow(try self.channel.configureWithHarness(harness))
+        XCTAssertNoThrow(try self.channel.client.pipeline.addHandler(handshaker).wait())
+        XCTAssertNoThrow(try self.channel.activate())
+        XCTAssertNoThrow(try self.channel.interactInMemory())
+
+        XCTAssertNoThrow(try promise.futureResult.wait())
+    }
+
+    func testCorrectBannerReceived() throws {
+        class ClientHandshakeHandler: ChannelInboundHandler {
+            typealias InboundIn = Any
+
+            static let expectedAuthBannerMessage = "This is a demo user auth banner."
+            static let expectedAuthBannerLanguageTag = "en"
+
+            var promise: EventLoopPromise<(String, String)>?
+
+            init(promise: EventLoopPromise<(String, String)>) {
+                self.promise = promise
+            }
+
+            func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+                guard let promise = self.promise else { return }
+                self.promise = nil
+
+                if let event = event as? UserAuthBannerEvent {
+                    promise.succeed((event.message, event.languageTag))
+                } else if event is UserAuthSuccessEvent {
+                    promise.fail(HandshakeFailure.missingBanner)
+                }
+            }
+
+            enum HandshakeFailure: Error {
+                case missingBanner
+            }
+        }
+
+        let promise = self.channel.client.eventLoop.makePromise(of: (String, String).self)
+        let handshaker = ClientHandshakeHandler(promise: promise)
+
+        var harness = TestHarness()
+        harness.serverAuthBanner = .init(message: ClientHandshakeHandler.expectedAuthBannerMessage, languageTag: ClientHandshakeHandler.expectedAuthBannerLanguageTag)
+
+        // Set up the connection, validate all is well.
+        XCTAssertNoThrow(try self.channel.configureWithHarness(harness))
+        XCTAssertNoThrow(try self.channel.client.pipeline.addHandler(handshaker).wait())
+        XCTAssertNoThrow(try self.channel.activate())
+        XCTAssertNoThrow(try self.channel.interactInMemory())
+
+        var banner = ("", "")
+        XCTAssertNoThrow(banner = try promise.futureResult.wait())
+        XCTAssertEqual(banner.0, ClientHandshakeHandler.expectedAuthBannerMessage)
+        XCTAssertEqual(banner.1, ClientHandshakeHandler.expectedAuthBannerLanguageTag)
     }
 
     func testHandshakeFailure() throws {

--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -130,7 +130,7 @@ struct TestHarness {
 
     var serverHostKeys: [NIOSSHPrivateKey] = [.init(ed25519Key: .init())]
 
-    var serverAuthBanner: SSHServerConfiguration.UserAuthBanner? = nil
+    var serverAuthBanner: SSHServerConfiguration.UserAuthBanner?
 }
 
 final class UserEventExpecter: ChannelInboundHandler {

--- a/Tests/NIOSSHTests/SSHMessagesTests.swift
+++ b/Tests/NIOSSHTests/SSHMessagesTests.swift
@@ -398,18 +398,18 @@ final class SSHMessagesTests: XCTestCase {
     }
 
     func testUserAuthBanner() throws {
-      var buffer = ByteBufferAllocator().buffer(capacity: 100)
-      let message = SSHMessage.userAuthBanner(.init(message: "Very important banner message containing crucial legal information.", languageTag: "en"))
-      
-      buffer.writeSSHMessage(message)
-      XCTAssertEqual(try buffer.readSSHMessage(), message)
-      
-      buffer.writeBytes([SSHMessage.UserAuthBannerMessage.id, 0, 0])
-      XCTAssertNil(try buffer.readSSHMessage())
-      
-      try self.assertCorrectlyManagesPartialRead(message)
+        var buffer = ByteBufferAllocator().buffer(capacity: 100)
+        let message = SSHMessage.userAuthBanner(.init(message: "Very important banner message containing crucial legal information.", languageTag: "en"))
+
+        buffer.writeSSHMessage(message)
+        XCTAssertEqual(try buffer.readSSHMessage(), message)
+
+        buffer.writeBytes([SSHMessage.UserAuthBannerMessage.id, 0, 0])
+        XCTAssertNil(try buffer.readSSHMessage())
+
+        try self.assertCorrectlyManagesPartialRead(message)
     }
-  
+
     func testGlobalRequest() throws {
         let allocator = ByteBufferAllocator()
         var buffer = allocator.buffer(capacity: 100)

--- a/Tests/NIOSSHTests/SSHMessagesTests.swift
+++ b/Tests/NIOSSHTests/SSHMessagesTests.swift
@@ -397,6 +397,19 @@ final class SSHMessagesTests: XCTestCase {
         try self.assertCorrectlyManagesPartialRead(message)
     }
 
+    func testUserAuthBanner() throws {
+      var buffer = ByteBufferAllocator().buffer(capacity: 100)
+      let message = SSHMessage.userAuthBanner(.init(message: "Very important banner message containing crucial legal information.", languageTag: "en"))
+      
+      buffer.writeSSHMessage(message)
+      XCTAssertEqual(try buffer.readSSHMessage(), message)
+      
+      buffer.writeBytes([SSHMessage.UserAuthBannerMessage.id, 0, 0])
+      XCTAssertNil(try buffer.readSSHMessage())
+      
+      try self.assertCorrectlyManagesPartialRead(message)
+    }
+  
     func testGlobalRequest() throws {
         let allocator = ByteBufferAllocator()
         var buffer = allocator.buffer(capacity: 100)


### PR DESCRIPTION
Hi everyone,

Upon using this excellent package to build an SSH client, I stumbled upon the following issue:

SSH servers may ask clients to display a userauth banner message during the user authentication step of the protocol. This mechanism is documented in RFC 4252. Since the underlying SSH_MSG_USERAUTH_BANNER message has thus far been entirely unimplemented, receiving userauth banners results in an 'unknownType(53)' error. This makes it impossible to connect to servers that send SSH_MSG_USERAUTH_BANNER using clients built with swift-nio-ssh - at least as far as I know.

This pull request aims to fix said issue, namely by implementing the userauth banner spec from RFC 4252.

I've thus far only encountered userauth banners that contained information about the underlying SSH server's hardware. I'd argue that this information is probably protection worthy, i.e., should not be disclosed to unauthorized third parties. I've thus taken the liberty to send banner messages from swift-nio-ssh servers right before user auth succeeds, to ensure that only authorized clients will receive banner message contents. This should technically be standards compliant, as RFC 4252 states: "_The SSH server may send an SSH_MSG_USERAUTH_BANNER message at any time after this authentication protocol starts and before authentication is successful._".
However, I'm afraid this implementation choice rules out some use cases, as the one mentioned in the RFC: "_In some jurisdictions, sending a warning message before authentication may be relevant for getting legal protection. [...] This message contains text to be displayed to the client user before authentication is attempted._".
Right now, I can see two plausible options IMHO:

1. send SSH_MSG_USERAUTH_BANNER at some earlier point in time, namely, before the client attempts to authenticate
2. let package users choose not only if but also when the banner is to be sent. The API should in this case be very clear, e.g., by differentiating between PublicUserAuthBanner and SecretUserAuthBanner types that are automatically handled at the appropriate times instead of a single UserAuthBanner type.

I'd really like to hear your opinions on this topic to make sure that the userauth banner implementation is in the best interest of all stakeholders of this package. In general, I appreciate all the feedback you can give. 

Thank you very much :)