### PR TITLE
Generate up to 8 random padding bytes at a time instead of 4

### DIFF
--- a/Sources/NIOSSH/ByteBuffer+SSH.swift
+++ b/Sources/NIOSSH/ByteBuffer+SSH.swift
@@ -180,7 +180,7 @@ extension ByteBuffer {
             let writtenBytes: Int
             switch necessaryPaddingBytes {
             case 8...:
-                writtenBytes = self.writeInteger(rng.next(), as: UInt32.self)
+                writtenBytes = self.writeInteger(rng.next(), as: UInt64.self)
             case 4 ... 7:
                 writtenBytes = self.writeInteger(rng.next(), as: UInt32.self)
             case 2 ... 3:


### PR DESCRIPTION
Fixes a (presumably copy-pasta) typo in `ByteBuffer.writeSSHPaddingBytes(count:)` where only 4 random bytes would be requested from the `CSPRNG` at a time even when 8 or more were needed. The only impact of this issue is a very small performance penalty (so small that it's likely unmeasurable outside of microbenchmarks in practice, in fact), but might as well fix it anyhow.