### PR TITLE
Add `PeerMaximumMessageLength` option for SSH child channels.

### DIFF
--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -26,7 +26,7 @@ public struct SSHChildChannelOptions {
 
     /// - seealso: `SSHChannelTypeOption`.
     public static let sshChannelType: SSHChildChannelOptions.Types.SSHChannelTypeOption = .init()
-    
+
     /// - seealso: `PeerMaximumMessageLengthOption`.
     public static let peerMaximumMessageLength: SSHChildChannelOptions.Types.PeerMaximumMessageLengthOption = .init()
 }
@@ -56,11 +56,11 @@ extension SSHChildChannelOptions.Types {
 
         public init() {}
     }
-    
+
     /// `PeerMaximumMessageLengthOption` allows users to query the maximum packet size value reported by the remote peer for a given channel.
     public struct PeerMaximumMessageLengthOption: ChannelOption {
         public typealias Value = UInt32
-        
+
         public init() {}
     }
 }

--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -26,6 +26,9 @@ public struct SSHChildChannelOptions {
 
     /// - seealso: `SSHChannelTypeOption`.
     public static let sshChannelType: SSHChildChannelOptions.Types.SSHChannelTypeOption = .init()
+    
+    /// - seealso: `PeerMaximumMessageLengthOption`.
+    public static let peerMaximumMessageLength: SSHChildChannelOptions.Types.PeerMaximumMessageLengthOption = .init()
 }
 
 extension SSHChildChannelOptions {
@@ -51,6 +54,13 @@ extension SSHChildChannelOptions.Types {
     public struct SSHChannelTypeOption: ChannelOption {
         public typealias Value = SSHChannelType
 
+        public init() {}
+    }
+    
+    /// `PeerMaximumMessageLengthOption` allows users to query the maximum packet size value reported by the remote peer for a given channel.
+    public struct PeerMaximumMessageLengthOption: ChannelOption {
+        public typealias Value = UInt32
+        
         public init() {}
     }
 }

--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -222,6 +222,8 @@ extension SSHChildChannel: Channel, ChannelCore {
             // This force-unwrap is safe: we set type before we call the initializer, so
             // users can only get this after this value is set.
             return self.type! as! Option.Value
+        case _ as SSHChildChannelOptions.Types.PeerMaximumMessageLengthOption:
+            return self.peerMaxMessageSize as! Option.Value
         case _ as ChannelOptions.Types.AutoReadOption:
             return self.autoRead as! Option.Value
         case _ as ChannelOptions.Types.AllowRemoteHalfClosureOption:

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -1751,7 +1751,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         let channelID = self.assertChannelOpen(harness.flushedMessages.first)
         XCTAssertNoThrow(try harness.multiplexer.receiveMessage(self.openConfirmation(originalChannelID: channelID!, peerChannelID: 1, initialWindowSize: 5, maxPacketSize: 4247)))
         XCTAssertTrue(channel.isWritable)
-        
+
         XCTAssertEqual(try channel.getOption(SSHChildChannelOptions.peerMaximumMessageLength).wait(), 4247)
     }
 }

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -1729,6 +1729,31 @@ final class ChildChannelMultiplexerTests: XCTestCase {
 
         self.assertChannelOpenConfirmation(harness.flushedMessages.first, recipientChannel: 1)
     }
+
+    func testChildChannelMaxMessageLengthOption() throws {
+        let harness = self.harnessForbiddingInboundChannels()
+        defer {
+            harness.finish()
+        }
+
+        var childChannel: Channel?
+        harness.multiplexer.createChildChannel(channelType: .session) { channel, _ in
+            childChannel = channel
+            return channel.eventLoop.makeSucceededFuture(())
+        }
+
+        guard let channel = childChannel else {
+            XCTFail("Did not create child channel")
+            return
+        }
+
+        // Activate channel.
+        let channelID = self.assertChannelOpen(harness.flushedMessages.first)
+        XCTAssertNoThrow(try harness.multiplexer.receiveMessage(self.openConfirmation(originalChannelID: channelID!, peerChannelID: 1, initialWindowSize: 5, maxPacketSize: 4247)))
+        XCTAssertTrue(channel.isWritable)
+        
+        XCTAssertEqual(try channel.getOption(SSHChildChannelOptions.peerMaximumMessageLength).wait(), 4247)
+    }
 }
 
 extension ByteBuffer {


### PR DESCRIPTION
Fixes #99 (see issue for details).