### PR TITLE
fixes an issue where decodeFirstBlock can be called multiple times

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -152,6 +152,7 @@ struct SSHConnectionStateMachine {
             }
         case .keyExchange(var state):
             guard let message = try state.parser.nextPacket() else {
+                self.state = .keyExchange(state)
                 return nil
             }
 
@@ -202,6 +203,7 @@ struct SSHConnectionStateMachine {
             }
         case .sentNewKeys(var state):
             guard let message = try state.parser.nextPacket() else {
+                self.state = .sentNewKeys(state)
                 return nil
             }
 
@@ -256,6 +258,7 @@ struct SSHConnectionStateMachine {
             // In this state we tolerate receiving service request messages. As we haven't sent newKeys, we cannot
             // send any user auth messages yet, so by definition we can't receive any other user auth message.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .receivedNewKeys(state)
                 return nil
             }
 
@@ -287,6 +290,7 @@ struct SSHConnectionStateMachine {
         case .userAuthentication(var state):
             // In this state we tolerate receiving user auth messages.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .userAuthentication(state)
                 return nil
             }
 
@@ -340,6 +344,7 @@ struct SSHConnectionStateMachine {
 
         case .active(var state):
             guard let message = try state.parser.nextPacket() else {
+                self.state = .active(state)
                 return nil
             }
 
@@ -405,6 +410,7 @@ struct SSHConnectionStateMachine {
             // We've received a key exchange packet. We only expect the first two messages (key exchange and key exchange init) before
             // we have sent a reply.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .receivedKexInitWhenActive(state)
                 return nil
             }
 
@@ -449,6 +455,7 @@ struct SSHConnectionStateMachine {
         case .sentKexInitWhenActive(var state):
             // We've sent a key exchange packet. We expect channel messages _or_ a kexinit packet.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .sentKexInitWhenActive(state)
                 return nil
             }
 
@@ -512,6 +519,7 @@ struct SSHConnectionStateMachine {
         case .rekeying(var state):
             // This is basically the regular key exchange state.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .rekeying(state)
                 return nil
             }
 
@@ -565,6 +573,7 @@ struct SSHConnectionStateMachine {
         case .rekeyingReceivedNewKeysState(var state):
             // This is basically a regular active state.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .rekeyingReceivedNewKeysState(state)
                 return nil
             }
 
@@ -625,6 +634,7 @@ struct SSHConnectionStateMachine {
         case .rekeyingSentNewKeysState(var state):
             // This is key exchange state.
             guard let message = try state.parser.nextPacket() else {
+                self.state = .rekeyingSentNewKeysState(state)
                 return nil
             }
 

--- a/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import NIO
+import NIOConcurrencyHelpers
 @testable import NIOSSH
 import XCTest
 
@@ -36,8 +37,15 @@ final class AcceptAllHostKeysDelegate: NIOSSHClientServerAuthenticationDelegate 
 
 final class SSHConnectionStateMachineTests: XCTestCase {
     private func assertSuccessfulConnection(client: inout SSHConnectionStateMachine, server: inout SSHConnectionStateMachine, allocator: ByteBufferAllocator, loop: EmbeddedEventLoop) throws {
-        var clientMessage: SSHMultiMessage? = client.start()
-        var serverMessage: SSHMultiMessage? = server.start()
+        let clientMessage: SSHMultiMessage? = client.start()
+        let serverMessage: SSHMultiMessage? = server.start()
+
+        try self.run(clientMessage: clientMessage, client: &client, serverMessage: serverMessage, server: &server, allocator: allocator, loop: loop)
+    }
+
+    private func run(clientMessage: SSHMultiMessage?, client: inout SSHConnectionStateMachine, serverMessage: SSHMultiMessage?, server: inout SSHConnectionStateMachine, allocator: ByteBufferAllocator, loop: EmbeddedEventLoop, dripFeed: Bool = false) throws {
+        var clientMessage = clientMessage
+        var serverMessage = serverMessage
         var clientBuffer = allocator.buffer(capacity: 1024)
         var serverBuffer = allocator.buffer(capacity: 1024)
         var waitingForClientMessage = false
@@ -57,12 +65,80 @@ final class SSHConnectionStateMachineTests: XCTestCase {
             }
 
             if clientBuffer.readableBytes > 0 {
-                server.bufferInboundData(&clientBuffer)
+                if dripFeed {
+                    while var next = clientBuffer.readSlice(length: 1) {
+                        server.bufferInboundData(&next)
+                        if clientBuffer.readableBytes > 0 {
+                            switch try assertNoThrowWithValue(server.processInboundMessage(allocator: allocator, loop: loop)) {
+                            case .some(.emitMessage(let message)):
+                                serverMessage.append(message)
+                            case .none:
+                                ()
+                            case .some(.noMessage):
+                                ()
+                            case .some(.possibleFutureMessage(let futureMessage)):
+                                waitingForServerMessage = true
+
+                                futureMessage.whenComplete { result in
+                                    waitingForServerMessage = false
+
+                                    switch result {
+                                    case .failure(let err):
+                                        XCTFail("Unexpected error in delayed message production: \(err)")
+                                    case .success(let message):
+                                        if let message = message {
+                                            serverMessage.append(message)
+                                        }
+                                    }
+                                }
+                            case .some(.forwardToMultiplexer), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect):
+                                fatalError("Currently unsupported")
+                            case .some(.event):
+                                ()
+                            }
+                        }
+                    }
+                } else {
+                    server.bufferInboundData(&clientBuffer)
+                }
                 clientBuffer.clear()
             }
 
             if serverBuffer.readableBytes > 0 {
-                client.bufferInboundData(&serverBuffer)
+                if dripFeed {
+                    while var next = serverBuffer.readSlice(length: 1) {
+                        client.bufferInboundData(&next)
+                        if serverBuffer.readableBytes > 0 {
+                            switch try assertNoThrowWithValue(client.processInboundMessage(allocator: allocator, loop: loop)) {
+                            case .some(.emitMessage(let message)):
+                                clientMessage.append(message)
+                            case .none:
+                                ()
+                            case .some(.noMessage):
+                                ()
+                            case .some(.possibleFutureMessage(let futureMessage)):
+                                waitingForClientMessage = true
+
+                                futureMessage.whenComplete { result in
+                                    waitingForClientMessage = false
+
+                                    switch result {
+                                    case .failure(let err):
+                                        XCTFail("Unexpected error in delayed message production: \(err)")
+                                    case .success(let message):
+                                        if let message = message {
+                                            clientMessage.append(message)
+                                        }
+                                    }
+                                }
+                            case .some(.forwardToMultiplexer), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event):
+                                fatalError("Currently unsupported")
+                            }
+                        }
+                    }
+                } else {
+                    client.bufferInboundData(&serverBuffer)
+                }
                 serverBuffer.clear()
             }
 
@@ -108,6 +184,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
                 case .some(.noMessage):
                     ()
                 case .some(.possibleFutureMessage(let futureMessage)):
+                    precondition(!waitingForServerMessage, "Unexpected emit message while another message is being processed")
                     waitingForServerMessage = true
 
                     futureMessage.whenComplete { result in
@@ -510,6 +587,54 @@ final class SSHConnectionStateMachineTests: XCTestCase {
 
         XCTAssertThrowsError(try client.processInboundMessage(allocator: allocator, loop: loop)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .unsupportedVersion)
+        }
+    }
+
+    func testFirstBlockDecodedOnce() throws {
+        let allocator = ByteBufferAllocator()
+        let loop = EmbeddedEventLoop()
+        let schemes: [NIOSSHTransportProtection.Type] = [TestTransportProtection.self]
+        var client = SSHConnectionStateMachine(role: .client(.init(userAuthDelegate: InfinitePasswordDelegate(), serverAuthDelegate: AcceptAllHostKeysDelegate())), protectionSchemes: schemes)
+        var server = SSHConnectionStateMachine(role: .server(.init(hostKeys: [NIOSSHPrivateKey(ed25519Key: .init())], userAuthDelegate: DenyThenAcceptDelegate(messagesToDeny: 0))), protectionSchemes: schemes)
+        try assertSuccessfulConnection(client: &client, server: &server, allocator: allocator, loop: loop)
+
+        let message = SSHMessage.channelData(.init(recipientChannel: 1, data: ByteBuffer(repeating: 17, count: 5)))
+
+        var tempBuffer = allocator.buffer(capacity: 1024)
+        XCTAssertNoThrow(try client.processOutboundMessage(message, buffer: &tempBuffer, allocator: allocator, loop: loop))
+        XCTAssert(tempBuffer.readableBytes > 0)
+
+        while var next = tempBuffer.readSlice(length: 1) {
+            server.bufferInboundData(&next)
+            if tempBuffer.readableBytes > 0 {
+                XCTAssertNil(try server.processInboundMessage(allocator: allocator, loop: loop))
+            }
+        }
+
+        var result = try server.processInboundMessage(allocator: allocator, loop: loop)
+        switch result {
+        case .some(.forwardToMultiplexer(let forwardedMessage)):
+            XCTAssertEqual(forwardedMessage, message)
+        case .some(.emitMessage), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event), .none:
+            XCTFail("Unexpected result: \(String(describing: result))")
+        }
+
+        tempBuffer.clear()
+        XCTAssertNoThrow(try client.beginRekeying(buffer: &tempBuffer, allocator: allocator, loop: loop))
+
+        while var next = tempBuffer.readSlice(length: 1) {
+            server.bufferInboundData(&next)
+            if tempBuffer.readableBytes > 0 {
+                XCTAssertNil(try server.processInboundMessage(allocator: allocator, loop: loop))
+            }
+        }
+
+        result = try server.processInboundMessage(allocator: allocator, loop: loop)
+        switch result {
+        case .some(.emitMessage(let message)):
+            XCTAssertNoThrow(try self.run(clientMessage: nil, client: &client, serverMessage: message, server: &server, allocator: allocator, loop: loop, dripFeed: true))
+        case .some(.forwardToMultiplexer), .some(.possibleFutureMessage), .some(.noMessage), .some(.globalRequest), .some(.globalRequestResponse), .some(.disconnect), .some(.event), .none:
+            XCTFail("Unexpected result: \(String(describing: result))")
         }
     }
 }

--- a/Tests/NIOSSHTests/Utilities.swift
+++ b/Tests/NIOSSHTests/Utilities.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Crypto
+import NIO
 @testable import NIOSSH
 import XCTest
 
@@ -25,5 +27,225 @@ func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue
         } else {
             throw error
         }
+    }
+}
+
+// This algorithm is not secure, used only for testing purposes
+struct InsecureEncryptionAlgorithm {
+    static func encrypt(key: ByteBuffer, plaintext: ByteBuffer) -> ByteBuffer {
+        var ciphertext = ByteBuffer()
+        var plaintext = plaintext
+        var key = key
+        guard let k0 = key.readInteger(as: UInt32.self),
+            let k1 = key.readInteger(as: UInt32.self),
+            let k2 = key.readInteger(as: UInt32.self),
+            let k3 = key.readInteger(as: UInt32.self) else {
+            preconditionFailure("check key size")
+        }
+
+        while var block = plaintext.readSlice(length: 16) {
+            guard var v0 = block.readInteger(as: UInt32.self),
+                var v1 = block.readInteger(as: UInt32.self),
+                var v2 = block.readInteger(as: UInt32.self),
+                var v3 = block.readInteger(as: UInt32.self) else {
+                preconditionFailure("check block size")
+            }
+
+            v0 = v0 ^ k0
+            v1 = v1 ^ k1
+            v2 = v2 ^ k2
+            v3 = v3 ^ k3
+
+            ciphertext.writeInteger(v0)
+            ciphertext.writeInteger(v1)
+            ciphertext.writeInteger(v2)
+            ciphertext.writeInteger(v3)
+        }
+        return ciphertext
+    }
+
+    static func decrypt(key: ByteBuffer, ciphertext: ByteBuffer) -> ByteBuffer {
+        var plaintext = ByteBuffer()
+        var ciphertext = ciphertext
+        var key = key
+        guard let k0 = key.readInteger(as: UInt32.self),
+            let k1 = key.readInteger(as: UInt32.self),
+            let k2 = key.readInteger(as: UInt32.self),
+            let k3 = key.readInteger(as: UInt32.self) else {
+            preconditionFailure("check key size")
+        }
+
+        while var block = ciphertext.readSlice(length: 16) {
+            guard var v0 = block.readInteger(as: UInt32.self),
+                var v1 = block.readInteger(as: UInt32.self),
+                var v2 = block.readInteger(as: UInt32.self),
+                var v3 = block.readInteger(as: UInt32.self) else {
+                preconditionFailure("check block size")
+            }
+
+            v0 = v0 ^ k0
+            v1 = v1 ^ k1
+            v2 = v2 ^ k2
+            v3 = v3 ^ k3
+
+            plaintext.writeInteger(v0)
+            plaintext.writeInteger(v1)
+            plaintext.writeInteger(v2)
+            plaintext.writeInteger(v3)
+        }
+
+        return plaintext
+    }
+}
+
+class TestTransportProtection: NIOSSHTransportProtection {
+    enum TestError: Error {
+        case doubleDecode
+    }
+
+    static var cipherBlockSize: Int {
+        16
+    }
+
+    var macBytes: Int {
+        32
+    }
+
+    static var cipherName: String {
+        "insecure-tiny-encription-cipher"
+    }
+
+    static var macName: String? {
+        nil
+    }
+
+    static var keySizes: ExpectedKeySizes {
+        .init(ivSize: 12, encryptionKeySize: 16, macKeySize: 16)
+    }
+
+    private var outboundEncryptionKey: ByteBuffer
+    private var inboundEncryptionKey: ByteBuffer
+    private var outboundMACKey: SymmetricKey
+    private var inboundMACKey: SymmetricKey
+
+    private var lastFirstBlock: ByteBufferView?
+
+    required init(initialKeys: NIOSSHSessionKeys) {
+        precondition(initialKeys.outboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+        precondition(initialKeys.inboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+        self.outboundEncryptionKey = initialKeys.outboundEncryptionKey.withUnsafeBytes {
+            ByteBuffer(bytes: $0)
+        }
+        self.inboundEncryptionKey = initialKeys.inboundEncryptionKey.withUnsafeBytes {
+            ByteBuffer(bytes: $0)
+        }
+        self.outboundMACKey = initialKeys.outboundMACKey
+        self.inboundMACKey = initialKeys.inboundMACKey
+    }
+
+    func updateKeys(_ newKeys: NIOSSHSessionKeys) throws {
+        precondition(newKeys.outboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+        precondition(newKeys.inboundEncryptionKey.bitCount == Self.keySizes.encryptionKeySize * 8)
+        self.outboundEncryptionKey = newKeys.outboundEncryptionKey.withUnsafeBytes {
+            ByteBuffer(bytes: $0)
+        }
+        self.inboundEncryptionKey = newKeys.inboundEncryptionKey.withUnsafeBytes {
+            ByteBuffer(bytes: $0)
+        }
+        self.outboundMACKey = newKeys.outboundMACKey
+        self.inboundMACKey = newKeys.inboundMACKey
+    }
+
+    func decryptFirstBlock(_ source: inout ByteBuffer) throws {
+        let index = source.readerIndex
+
+        guard let ciphertextView = source.viewBytes(at: index, length: Self.cipherBlockSize),
+            ciphertextView.count > 0, ciphertextView.count % Self.cipherBlockSize == 0 else {
+            // The only way this fails is if the payload doesn't match this encryption scheme.
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        if self.lastFirstBlock == ciphertextView {
+            throw TestError.doubleDecode
+        }
+
+        self.lastFirstBlock = ciphertextView
+
+        let plaintext = InsecureEncryptionAlgorithm.decrypt(key: self.inboundEncryptionKey, ciphertext: ByteBuffer(bytes: ciphertextView))
+
+        source.setBytes(plaintext.readableBytesView, at: index)
+    }
+
+    func decryptAndVerifyRemainingPacket(_ source: inout ByteBuffer) throws -> ByteBuffer {
+        defer {
+            self.lastFirstBlock = nil
+        }
+
+        guard var plaintext = source.readSlice(length: Self.cipherBlockSize) else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        // First block is expected to be decoded by decodeFirstBlock
+        if source.readableBytes > self.macBytes {
+            guard let ciphertext = source.readSlice(length: source.readableBytes - 32),
+                ciphertext.readableBytes > 0, ciphertext.readableBytes % Self.cipherBlockSize == 0 else {
+                // The only way this fails is if the payload doesn't match this encryption scheme.
+                throw NIOSSHError.invalidEncryptedPacketLength
+            }
+
+            var tail = InsecureEncryptionAlgorithm.decrypt(key: self.inboundEncryptionKey, ciphertext: ciphertext)
+            plaintext.writeBuffer(&tail)
+        }
+
+        guard let tagView = source.readSlice(length: 32)?.readableBytesView else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        guard HMAC<SHA256>.isValidAuthenticationCode(tagView, authenticating: plaintext.readableBytesView, using: self.inboundMACKey) else {
+            preconditionFailure("authentication failure")
+        }
+
+        // First 4 bytes are length
+        plaintext.moveReaderIndex(forwardBy: 4)
+        let paddingLength = plaintext.readInteger(as: UInt8.self)!
+        return plaintext.readSlice(length: plaintext.readableBytes - Int(paddingLength))!
+    }
+
+    func encryptPacket(_ packet: NIOSSHEncryptablePayload, to outboundBuffer: inout ByteBuffer) throws {
+        let packetLengthIndex = outboundBuffer.writerIndex
+        let packetLengthLength = MemoryLayout<UInt32>.size
+        let packetPaddingIndex = outboundBuffer.writerIndex + packetLengthLength
+        let packetPaddingLength = MemoryLayout<UInt8>.size
+
+        outboundBuffer.moveWriterIndex(forwardBy: packetLengthLength + packetPaddingLength)
+
+        let payloadBytes = outboundBuffer.writeEncryptablePayload(packet)
+
+        var encryptedBufferSize = payloadBytes + packetPaddingLength + packetLengthLength
+        var necessaryPaddingBytes = Self.cipherBlockSize - (encryptedBufferSize % Self.cipherBlockSize)
+        if necessaryPaddingBytes < 4 {
+            necessaryPaddingBytes += Self.cipherBlockSize
+        }
+
+        // We now want to write that many padding bytes to the end of the buffer. These are supposed to be
+        // random bytes. We're going to get those from the system random number generator.
+        encryptedBufferSize += outboundBuffer.writeSSHPaddingBytes(count: necessaryPaddingBytes)
+        precondition(encryptedBufferSize % Self.cipherBlockSize == 0, "Incorrectly counted buffer size; got \(encryptedBufferSize)")
+
+        // We now know the length: it's going to be "encrypted buffer size". The length does not include the tag, so don't add it.
+        // Let's write that in. We also need to write the number of padding bytes in.
+        outboundBuffer.setInteger(UInt32(encryptedBufferSize - packetLengthLength), at: packetLengthIndex)
+        outboundBuffer.setInteger(UInt8(necessaryPaddingBytes), at: packetPaddingIndex)
+        let plaintextView = outboundBuffer.viewBytes(at: packetLengthIndex, length: encryptedBufferSize)!
+        let ciphertext = InsecureEncryptionAlgorithm.encrypt(key: self.outboundEncryptionKey, plaintext: ByteBuffer(bytes: plaintextView))
+        assert(ciphertext.readableBytes == encryptedBufferSize)
+
+        var hmac = HMAC<SHA256>.init(key: self.outboundMACKey)
+        hmac.update(data: plaintextView)
+
+        // We now want to overwrite the portion of the bytebuffer that contains the plaintext with the ciphertext, and then append the tag.
+        outboundBuffer.setBytes(ciphertext.readableBytesView, at: packetLengthIndex)
+        let tagLength = outboundBuffer.writeBytes(hmac.finalize())
+        precondition(tagLength == self.macBytes, "Unexpected short tag")
     }
 }

--- a/Tests/NIOSSHTests/UtilitiesTests.swift
+++ b/Tests/NIOSSHTests/UtilitiesTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2020 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIOCore
+@testable import NIOSSH
+import XCTest
+
+final class UtilitiesTests: XCTestCase {
+    func testInsecureEncryptionAlgorithm() {
+        let message = ByteBuffer([0, 42, 1, 17, 17, 1, 42, 0, 77, 33, 178, 75, 165, 60, 168, 69, 203, 63, 34, 230, 38, 242, 58, 21, 17, 0, 1, 77, 31, 8, 11, 7])
+        let key = SymmetricKey(size: .bits128).withUnsafeBytes {
+            ByteBuffer(bytes: $0)
+        }
+        let ciphertext = InsecureEncryptionAlgorithm.encrypt(key: key, plaintext: message)
+        let plaintext = InsecureEncryptionAlgorithm.decrypt(key: key, ciphertext: ciphertext)
+        XCTAssertEqual(message, plaintext)
+    }
+
+    func testTestTransportProtection() throws {
+        let inboundEncryptionKey = SymmetricKey(size: .bits128)
+        let outboundEncryptionKey = SymmetricKey(size: .bits128)
+        let inboundMACKey = SymmetricKey(size: .bits128)
+        let outboundMACKey = SymmetricKey(size: .bits128)
+        let client = TestTransportProtection(initialKeys: .init(
+            initialInboundIV: [],
+            initialOutboundIV: [],
+            inboundEncryptionKey: inboundEncryptionKey,
+            outboundEncryptionKey: outboundEncryptionKey,
+            inboundMACKey: inboundMACKey,
+            outboundMACKey: outboundMACKey
+        ))
+        let server = TestTransportProtection(initialKeys: .init(
+            initialInboundIV: [],
+            initialOutboundIV: [],
+            inboundEncryptionKey: outboundEncryptionKey,
+            outboundEncryptionKey: inboundEncryptionKey,
+            inboundMACKey: outboundMACKey,
+            outboundMACKey: inboundMACKey
+        ))
+        let message = SSHMessage.channelRequest(.init(recipientChannel: 1, type: .exec("uname"), wantReply: false))
+        let allocator = ByteBufferAllocator()
+        var buffer = allocator.buffer(capacity: 1024)
+        XCTAssertNoThrow(try client.encryptPacket(.init(message: message), to: &buffer))
+        XCTAssertNoThrow(try server.decryptFirstBlock(&buffer))
+        var decoded = try server.decryptAndVerifyRemainingPacket(&buffer)
+        XCTAssertEqual(message, try decoded.readSSHMessage())
+    }
+}


### PR DESCRIPTION
Motivation:
When we call `decodeFirstBlock` we expect that first blockSize bytes,
that include packet length, will be overwritten in the parser buffer
(this is why we pass source byte buffer as inout). This changes state of
the parser, but if we cannot decode a packet we do not return it and in
the connection state machine we return without updating the machine
state. This can lead to calling decodeFirstBlock multiple times until we
have enough data to decode the whole packet in one go.

Modifications:
 - Update connection state machine state when active even if we do not
   have response message
 - Adds TinyEncriptionAlgorithm implementation to test codepaths that
   use decodeFirstBlock (unlike AESGCM)
 - Test that drip feeds data to parser