### PR TITLE
ci update

### DIFF
--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -3,17 +3,16 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-nio-ssh:20.04-5.6
+    image: swift-nio-ssh:20.04-5.7
     build:
       args:
-        ubuntu_version: "focal"
-        swift_version: "5.6"
+        base_image: "swiftlang/swift:nightly-main-focal"
 
   test:
-    image: swift-nio-ssh:20.04-5.6
+    image: swift-nio-ssh:20.04-5.7
     environment: []
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
 
   shell:
-    image: swift-nio-ssh:20.04-5.6
+    image: swift-nio-ssh:20.04-5.7

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -7,7 +7,6 @@ services:
     build:
       args:
         base_image: "swiftlang/swift:nightly-main-focal"
-        ubuntu_version: "focal"
 
   test:
     image: swift-nio-ssh:20.04-main


### PR DESCRIPTION
motivation: 5.6 is out

changes:
* use release version of 5.6
* add docker setup for 5.7 (using nightly for now)