### PR TITLE
Adopt `Sendable` on our public types

### DIFF
--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -37,28 +37,28 @@ extension SSHChildChannelOptions {
 
 extension SSHChildChannelOptions.Types {
     /// `LocalChannelIdentifierOption` allows users to query the channel number assigned locally for a given channel.
-    public struct LocalChannelIdentifierOption: ChannelOption {
+    public struct LocalChannelIdentifierOption: ChannelOption, NIOSSHSendable {
         public typealias Value = UInt32
 
         public init() {}
     }
 
     /// `RemoteChannelIdentifierOption` allows users to query the channel number assigned by the remote peer for a given channel.
-    public struct RemoteChannelIdentifierOption: ChannelOption {
+    public struct RemoteChannelIdentifierOption: ChannelOption, NIOSSHSendable {
         public typealias Value = UInt32?
 
         public init() {}
     }
 
     /// `SSHChannelTypeOption` allows users to query the type of the channel they're currently using.
-    public struct SSHChannelTypeOption: ChannelOption {
+    public struct SSHChannelTypeOption: ChannelOption, NIOSSHSendable {
         public typealias Value = SSHChannelType
 
         public init() {}
     }
 
     /// `PeerMaximumMessageLengthOption` allows users to query the maximum packet size value reported by the remote peer for a given channel.
-    public struct PeerMaximumMessageLengthOption: ChannelOption {
+    public struct PeerMaximumMessageLengthOption: ChannelOption, NIOSSHSendable {
         public typealias Value = UInt32
 
         public init() {}

--- a/Sources/NIOSSH/Child Channels/ChildChannelUserEvents.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelUserEvents.swift
@@ -16,7 +16,7 @@ import NIOCore
 
 /// A namespace for SSH channel request events.
 public enum SSHChannelRequestEvent {
-    public struct PseudoTerminalRequest: Hashable {
+    public struct PseudoTerminalRequest: Hashable, NIOSSHSendable {
         /// Whether a reply to this PTY request is desired.
         public var wantReply: Bool
 
@@ -92,7 +92,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// An EnvironmentRequest communicates a single environment variable the peer wants set.
-    public struct EnvironmentRequest: Hashable {
+    public struct EnvironmentRequest: Hashable, NIOSSHSendable {
         /// The name of the environment variable.
         public var name: String
 
@@ -110,7 +110,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// A request for this session to invoke a shell.
-    public struct ShellRequest: Hashable {
+    public struct ShellRequest: Hashable, NIOSSHSendable {
         /// Whether this request should be replied to.
         public var wantReply: Bool
 
@@ -134,7 +134,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// The command has exited with the given exit status.
-    public struct ExitStatus: Hashable {
+    public struct ExitStatus: Hashable, NIOSSHSendable {
         /// Whether this request should be replied to.
         public var wantReply: Bool {
             false
@@ -162,7 +162,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// A command has terminated in response to a signal.
-    public struct ExitSignal: Hashable {
+    public struct ExitSignal: Hashable, NIOSSHSendable {
         /// Whether this request should be replied to.
         public var wantReply: Bool {
             false
@@ -189,7 +189,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// A request for this session to invoke a specific subsystem.
-    public struct SubsystemRequest: Hashable {
+    public struct SubsystemRequest: Hashable, NIOSSHSendable {
         /// Whether this request wants a reply.
         public var wantReply: Bool
 
@@ -202,7 +202,7 @@ public enum SSHChannelRequestEvent {
         }
     }
 
-    public struct WindowChangeRequest: Hashable {
+    public struct WindowChangeRequest: Hashable, NIOSSHSendable {
         /// Whether a reply to this window change request is desired.
         public var wantReply: Bool {
             false
@@ -265,7 +265,7 @@ public enum SSHChannelRequestEvent {
     ///
     /// This is sent by the server. If "client can do" is true, the client may do flow control with
     /// ctrl+s and ctrl+q.
-    public struct LocalFlowControlRequest: Hashable {
+    public struct LocalFlowControlRequest: Hashable, NIOSSHSendable {
         /// Whether a reply to this request is desired.
         public var wantReply: Bool {
             false
@@ -280,7 +280,7 @@ public enum SSHChannelRequestEvent {
     }
 
     /// Delivers a signal to the remote process.
-    public struct SignalRequest: Hashable {
+    public struct SignalRequest: Hashable, NIOSSHSendable {
         /// Whether a reply to this request is desired.
         public var wantReply: Bool {
             false
@@ -337,12 +337,12 @@ extension SSHChannelRequestEvent {
 }
 
 /// A channel success message was received in reply to a channel request.
-public struct ChannelSuccessEvent: Hashable {
+public struct ChannelSuccessEvent: Hashable, NIOSSHSendable {
     public init() {}
 }
 
 /// A channel failure message was received in reply to a channel request.
-public struct ChannelFailureEvent: Hashable {
+public struct ChannelFailureEvent: Hashable, NIOSSHSendable {
     public init() {}
 }
 

--- a/Sources/NIOSSH/Child Channels/SSHChannelData.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelData.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=5.6)
+@preconcurrency import NIOCore
+#else
 import NIOCore
+#endif // swift(>=5.6)
 
 /// `SSHChannelData` is the data type that is passed around in `SSHChildChannel` objects.
 ///
@@ -31,6 +35,8 @@ public struct SSHChannelData {
 }
 
 extension SSHChannelData: Equatable {}
+
+extension SSHChannelData: NIOSSHSendable {}
 
 extension SSHChannelData {
     /// The type of this channel data. Regular `.channel` data is the standard type of data on an `SSHChannel`,
@@ -57,6 +63,8 @@ extension SSHChannelData {
 }
 
 extension SSHChannelData.DataType: Hashable {}
+
+extension SSHChannelData.DataType: NIOSSHSendable {}
 
 extension SSHChannelData.DataType: CustomStringConvertible {
     public var description: String {

--- a/Sources/NIOSSH/Child Channels/SSHChannelType.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelType.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if swift(>=5.6)
+@preconcurrency import NIOCore
+#else
 import NIOCore
+#endif // swift(>=5.6)
 
 /// `SSHChannelType` represents the type of a single SSH channel.
 ///
@@ -25,7 +29,7 @@ import NIOCore
 ///
 /// Some channel types have associated metadata. That metadata can be retrieved from SSH channels using
 /// channel options.
-public enum SSHChannelType: Equatable {
+public enum SSHChannelType: Equatable, NIOSSHSendable {
     /// A "session" is remote execution of a program.
     case session
 
@@ -37,7 +41,7 @@ public enum SSHChannelType: Equatable {
 }
 
 extension SSHChannelType {
-    public struct DirectTCPIP: Equatable {
+    public struct DirectTCPIP: Equatable, NIOSSHSendable {
         /// The target host for the forwarded TCP connection.
         public var targetHost: String
 
@@ -71,7 +75,7 @@ extension SSHChannelType {
 }
 
 extension SSHChannelType {
-    public struct ForwardedTCPIP: Equatable {
+    public struct ForwardedTCPIP: Equatable, NIOSSHSendable {
         /// The host the remote peer connected to. This should be identical to the one that was requested.
         public var listeningHost: String
 

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -19,7 +19,7 @@ import NIOCore
 import Darwin
 #else
 import Glibc
-#endif
+#endif // os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 
 /// A `NIOSSHCertifiedPublicKey` is an SSH public key combined with an SSH certificate.
 ///

--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -28,6 +28,8 @@ public struct NIOSSHError: Error {
     private var diagnostics: String?
 }
 
+extension NIOSSHError: NIOSSHSendable {}
+
 // MARK: - Internal helper functions for error construction.
 
 // These are never inlined as they are inherently cold path functions.
@@ -282,6 +284,10 @@ extension NIOSSHError {
 // MARK: - NIOSSHError.ErrorType Hashable conformance
 
 extension NIOSSHError.ErrorType: Hashable {}
+
+// MARK: - NIOSSHError.ErrorType Sendable conformance
+
+extension NIOSSHError.ErrorType: NIOSSHSendable {}
 
 // MARK: - NIOSSHError.ErrorType CustomStringConvertible conformance
 

--- a/Sources/NIOSSH/NIOSSHSendable.swift
+++ b/Sources/NIOSSH/NIOSSHSendable.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if swift(>=5.6)
+@preconcurrency protocol NIOSSHSendable: Sendable {}
+#else
+protocol NIOSSHSendable: Any {}
+#endif // swift(>=5.6)

--- a/Sources/NIOSSH/SSHTerminalModes.swift
+++ b/Sources/NIOSSH/SSHTerminalModes.swift
@@ -28,6 +28,8 @@ public struct SSHTerminalModes {
 
 extension SSHTerminalModes: Hashable {}
 
+extension SSHTerminalModes: NIOSSHSendable {}
+
 // MARK: Opcode
 
 extension SSHTerminalModes {
@@ -220,6 +222,8 @@ extension SSHTerminalModes {
 
 extension SSHTerminalModes.Opcode: Hashable {}
 
+extension SSHTerminalModes.Opcode: NIOSSHSendable {}
+
 extension SSHTerminalModes.Opcode: Comparable {
     public static func < (lhs: SSHTerminalModes.Opcode, rhs: SSHTerminalModes.Opcode) -> Bool {
         lhs.rawValue < rhs.rawValue
@@ -368,6 +372,8 @@ extension SSHTerminalModes {
 }
 
 extension SSHTerminalModes.OpcodeValue: Hashable {}
+
+extension SSHTerminalModes.OpcodeValue: NIOSSHSendable {}
 
 extension SSHTerminalModes.OpcodeValue: Comparable {
     public static func < (lhs: SSHTerminalModes.OpcodeValue, rhs: SSHTerminalModes.OpcodeValue) -> Bool {

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
+    sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/2019-2020/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/' -e 's/2022/YEARS/'
 }
 
 command -v swiftformat >/dev/null 2>&1 || { echo >&2 "swiftformat needs to be installed but is not available in the path."; exit 1; }


### PR DESCRIPTION
# Motivation
We need to adopt `Sendable` on certain types that are prone to be shared across threads.

# Modification
Adopt `Sendable` on some types.

# Result
Our types are `Sendable`