### PR TITLE
fix typo in state machine type

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
+++ b/Sources/NIOSSH/Connection State Machine/SSHConnectionStateMachine.swift
@@ -38,7 +38,7 @@ struct SSHConnectionStateMachine {
         case active(ActiveState)
 
         /// We have received a KeyExchangeInit message from the active state, and so will be rekeying shortly.
-        case receivedKexInitWhenActive(ReceivedKexInitWhenActiveState)
+        case receivedKexInitWhenActive(ReceivedKeyInitWhenActiveState)
 
         /// We have sent a KeyExchangeInit message from the active state, and so will be rekeying shortly.
         case sentKexInitWhenActive(SentKexInitWhenActiveState)
@@ -385,7 +385,7 @@ struct SSHConnectionStateMachine {
                 return .globalRequestResponse(.failure)
             case .keyExchange(let message):
                 // Attempting to rekey.
-                var newState = ReceivedKexInitWhenActiveState(state, allocator: allocator, loop: loop)
+                var newState = ReceivedKeyInitWhenActiveState(state, allocator: allocator, loop: loop)
                 let result = try newState.receiveKeyExchangeMessage(message)
                 self.state = .receivedKexInitWhenActive(newState)
                 return result

--- a/Sources/NIOSSH/Connection State Machine/States/ReceivedKeyInitWhenActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/ReceivedKeyInitWhenActiveState.swift
@@ -17,7 +17,7 @@ extension SSHConnectionStateMachine {
     /// The state of a state machine that has received a KeyExchangeInit message after
     /// having been active. In this state, no further channel messages may be sent by the
     /// remote peer until key exchange is done. We can send channel messages _and_ key exchange init.
-    struct ReceivedKexInitWhenActiveState {
+    struct ReceivedKeyInitWhenActiveState {
         /// The role of the connection
         let role: SSHConnectionRole
 
@@ -46,8 +46,8 @@ extension SSHConnectionStateMachine {
     }
 }
 
-extension SSHConnectionStateMachine.ReceivedKexInitWhenActiveState: AcceptsKeyExchangeMessages {}
+extension SSHConnectionStateMachine.ReceivedKeyInitWhenActiveState: AcceptsKeyExchangeMessages {}
 
-extension SSHConnectionStateMachine.ReceivedKexInitWhenActiveState: SendsChannelMessages {}
+extension SSHConnectionStateMachine.ReceivedKeyInitWhenActiveState: SendsChannelMessages {}
 
-extension SSHConnectionStateMachine.ReceivedKexInitWhenActiveState: SendsKeyExchangeMessages {}
+extension SSHConnectionStateMachine.ReceivedKeyInitWhenActiveState: SendsKeyExchangeMessages {}

--- a/Sources/NIOSSH/Connection State Machine/States/RekeyingState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/RekeyingState.swift
@@ -35,7 +35,7 @@ extension SSHConnectionStateMachine {
         /// The backing state machine.
         var keyExchangeStateMachine: SSHKeyExchangeStateMachine
 
-        init(_ previousState: ReceivedKexInitWhenActiveState) {
+        init(_ previousState: ReceivedKeyInitWhenActiveState) {
             self.role = previousState.role
             self.parser = previousState.parser
             self.serializer = previousState.serializer


### PR DESCRIPTION
While working on the custom cryptography PR I ran across this small nit (easier to review this way) 