### PR TITLE
Refactoring of the encryptPacket method

### DIFF
--- a/Sources/NIOSSH/SSHPacketSerializer.swift
+++ b/Sources/NIOSSH/SSHPacketSerializer.swift
@@ -47,40 +47,55 @@ struct SSHPacketSerializer {
                 preconditionFailure("only .version message is allowed at this point")
             }
         case .cleartext:
-            let index = buffer.writerIndex
-
-            /// Each packet is in the following format:
-            ///
-            ///   uint32        packet_length
-            ///   byte           padding_length
-            ///   byte[n1]  payload; n1 = packet_length - padding_length - 1
-            ///   byte[n2]  random padding; n2 = padding_length
-            ///   byte[m]   mac (Message Authentication Code - MAC); m = mac_length
-
-            /// payload
-            buffer.moveWriterIndex(forwardBy: 5)
-            let messageLength = buffer.writeSSHMessage(message)
-
-            /// RFC 4253 § 6:
-            /// random padding
-            ///   Arbitrary-length padding, such that the total length of (packet_length || padding_length || payload || random padding)
-            ///   is a multiple of the cipher block size or 8, whichever is larger.  There MUST be at least four bytes of padding.  The
-            ///   padding SHOULD consist of random bytes.  The maximum amount of padding is 255 bytes.
-            let blockSize = 8
-            let paddingLength = 3 + blockSize - ((messageLength + blockSize) % blockSize)
-
-            /// packet_length
-            ///   The length of the packet in bytes, not including 'mac' or the 'packet_length' field itself.
-            buffer.setInteger(UInt32(1 + messageLength + paddingLength), at: index)
-            /// padding_length
-            buffer.setInteger(UInt8(paddingLength), at: index + 4)
-            /// random padding
-            buffer.writeSSHPaddingBytes(count: paddingLength)
+            buffer.writeSSHPacket(message: message, lengthEncrypted: true, blockSize: 8)
             self.sequenceNumber &+= 1
         case .encrypted(let protection):
-            let payload = NIOSSHEncryptablePayload(message: message)
-            try protection.encryptPacket(payload, sequenceNumber: self.sequenceNumber, to: &buffer)
+            let index = buffer.readerIndex
+            buffer.moveReaderIndex(to: buffer.writerIndex)
+            buffer.writeSSHPacket(message: message, lengthEncrypted: protection.lengthEncrypted, blockSize: protection.cipherBlockSize)
+            try protection.encryptPacket(&buffer, sequenceNumber: self.sequenceNumber)
+            buffer.moveReaderIndex(to: index)
             self.sequenceNumber &+= 1
         }
+    }
+}
+
+extension ByteBuffer {
+    mutating func writeSSHPacket(message: SSHMessage, lengthEncrypted: Bool, blockSize: Int) {
+        let index = self.writerIndex
+
+        /// Each packet is in the following format:
+        ///
+        ///   uint32        packet_length
+        ///   byte           padding_length
+        ///   byte[n1]  payload; n1 = packet_length - padding_length - 1
+        ///   byte[n2]  random padding; n2 = padding_length
+        ///   byte[m]   mac (Message Authentication Code - MAC); m = mac_length
+
+        /// payload
+        self.moveWriterIndex(forwardBy: 5)
+        let messageLength = self.writeSSHMessage(message)
+
+        // Depending on on whether packet length is encrypted, padding should reflect that
+        let payloadLength = lengthEncrypted ? messageLength + 5 : messageLength + 1
+
+        /// RFC 4253 § 6:
+        /// random padding
+        ///   Arbitrary-length padding, such that the total length of (packet_length || padding_length || payload || random padding)
+        ///   is a multiple of the cipher block size or 8, whichever is larger.  There MUST be at least four bytes of padding.  The
+        ///   padding SHOULD consist of random bytes.  The maximum amount of padding is 255 bytes.
+        var paddingLength = blockSize - (payloadLength % blockSize)
+        if paddingLength < 4 {
+            paddingLength += blockSize
+        }
+
+        /// packet_length
+        ///   The length of the packet in bytes, not including 'mac' or the 'packet_length' field itself.
+        let packetLength = 1 + messageLength + paddingLength
+        self.setInteger(UInt32(packetLength), at: index)
+        /// padding_length
+        self.setInteger(UInt8(paddingLength), at: index + 4)
+        /// random padding
+        self.writeSSHPaddingBytes(count: paddingLength)
     }
 }

--- a/Sources/NIOSSH/TransportProtection/SSHTransportProtection.swift
+++ b/Sources/NIOSSH/TransportProtection/SSHTransportProtection.swift
@@ -61,6 +61,10 @@ public protocol NIOSSHTransportProtection: AnyObject {
     /// The number of bytes consumed by the MAC
     var macBytes: Int { get }
 
+    /// Whether legnth of the packet will be encrypted. If length is not encrypted, it should be counted
+    /// when padding size is calculated.
+    var lengthEncrypted: Bool { get }
+
     /// Create a new instance of this transport protection scheme with the given keys.
     init(initialKeys: NIOSSHSessionKeys) throws
 
@@ -90,7 +94,7 @@ public protocol NIOSSHTransportProtection: AnyObject {
     func decryptAndVerifyRemainingPacket(_ source: inout ByteBuffer, sequenceNumber: UInt32) throws -> ByteBuffer
 
     /// Encrypt an entire outbound packet
-    func encryptPacket(_ packet: NIOSSHEncryptablePayload, sequenceNumber: UInt32, to outboundBuffer: inout ByteBuffer) throws
+    func encryptPacket(_ destination: inout ByteBuffer, sequenceNumber: UInt32) throws
 }
 
 extension NIOSSHTransportProtection {

--- a/Tests/NIOSSHTests/AESGCMTests.swift
+++ b/Tests/NIOSSHTests/AESGCMTests.swift
@@ -42,7 +42,9 @@ final class AESGCMTests: XCTestCase {
         let initialKeys = self.generateKeys(keySize: .bits128)
 
         let aes128Encryptor = try assertNoThrowWithValue(AES128GCMOpenSSHTransportProtection(initialKeys: initialKeys))
-        XCTAssertNoThrow(try aes128Encryptor.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), sequenceNumber: 0, to: &self.buffer))
+
+        self.buffer.writeSSHPacket(message: .newKeys, lengthEncrypted: aes128Encryptor.lengthEncrypted, blockSize: aes128Encryptor.cipherBlockSize)
+        XCTAssertNoThrow(try aes128Encryptor.encryptPacket(&self.buffer, sequenceNumber: 0))
 
         // The newKeys message is very straightforward: a single byte. Because of that, we expect that we will need
         // 14 padding bytes: one byte for the padding length, then 14 more to get out to one block size. Thus, the total
@@ -77,7 +79,9 @@ final class AESGCMTests: XCTestCase {
         let initialKeys = self.generateKeys(keySize: .bits256)
 
         let aes256Encryptor = try assertNoThrowWithValue(AES256GCMOpenSSHTransportProtection(initialKeys: initialKeys))
-        XCTAssertNoThrow(try aes256Encryptor.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), sequenceNumber: 0, to: &self.buffer))
+
+        self.buffer.writeSSHPacket(message: .newKeys, lengthEncrypted: aes256Encryptor.lengthEncrypted, blockSize: aes256Encryptor.cipherBlockSize)
+        XCTAssertNoThrow(try aes256Encryptor.encryptPacket(&self.buffer, sequenceNumber: 0))
 
         // The newKeys message is very straightforward: a single byte. Because of that, we expect that we will need
         // 14 padding bytes: one byte for the padding length, then 14 more to get out to one block size. Thus, the total

--- a/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
@@ -144,7 +144,8 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
         var buffer = ByteBufferAllocator().buffer(capacity: 1024)
 
         do {
-            try client.encryptPacket(.init(message: message), sequenceNumber: 0, to: &buffer)
+            buffer.writeSSHPacket(message: message, lengthEncrypted: client.lengthEncrypted, blockSize: client.cipherBlockSize)
+            try client.encryptPacket(&buffer, sequenceNumber: 0)
             try server.decryptFirstBlock(&buffer)
             var messageBuffer = try server.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)
             let decrypted = try messageBuffer.readSSHMessage()
@@ -158,7 +159,8 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
         buffer.clear()
 
         do {
-            try server.encryptPacket(.init(message: message), sequenceNumber: 0, to: &buffer)
+            buffer.writeSSHPacket(message: message, lengthEncrypted: server.lengthEncrypted, blockSize: server.cipherBlockSize)
+            try server.encryptPacket(&buffer, sequenceNumber: 0)
             try client.decryptFirstBlock(&buffer)
             var messageBuffer = try client.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)
             let decrypted = try messageBuffer.readSSHMessage()

--- a/Tests/NIOSSHTests/SSHPacketParserTests.swift
+++ b/Tests/NIOSSHTests/SSHPacketParserTests.swift
@@ -251,7 +251,8 @@ final class SSHPacketParserTests: XCTestCase {
         parser.addEncryption(protection)
 
         part = allocator.buffer(capacity: 1024)
-        XCTAssertNoThrow(try protection.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), sequenceNumber: 2, to: &part))
+        part.writeSSHPacket(message: .newKeys, lengthEncrypted: protection.lengthEncrypted, blockSize: protection.cipherBlockSize)
+        XCTAssertNoThrow(try protection.encryptPacket(&part, sequenceNumber: 2))
         var subpart = part.readSlice(length: 2)!
         parser.append(bytes: &subpart)
 
@@ -268,7 +269,8 @@ final class SSHPacketParserTests: XCTestCase {
         }
 
         part = allocator.buffer(capacity: 1024)
-        XCTAssertNoThrow(try protection.encryptPacket(NIOSSHEncryptablePayload(message: .newKeys), sequenceNumber: 2, to: &part))
+        part.writeSSHPacket(message: .newKeys, lengthEncrypted: protection.lengthEncrypted, blockSize: protection.cipherBlockSize)
+        XCTAssertNoThrow(try protection.encryptPacket(&part, sequenceNumber: 2))
         parser.append(bytes: &part)
 
         switch try parser.nextPacket() {

--- a/Tests/NIOSSHTests/UtilitiesTests.swift
+++ b/Tests/NIOSSHTests/UtilitiesTests.swift
@@ -52,7 +52,10 @@ final class UtilitiesTests: XCTestCase {
         let message = SSHMessage.channelRequest(.init(recipientChannel: 1, type: .exec("uname"), wantReply: false))
         let allocator = ByteBufferAllocator()
         var buffer = allocator.buffer(capacity: 1024)
-        XCTAssertNoThrow(try client.encryptPacket(.init(message: message), sequenceNumber: 0, to: &buffer))
+
+        buffer.writeSSHPacket(message: message, lengthEncrypted: client.lengthEncrypted, blockSize: client.cipherBlockSize)
+
+        XCTAssertNoThrow(try client.encryptPacket(&buffer, sequenceNumber: 0))
         XCTAssertNoThrow(try server.decryptFirstBlock(&buffer))
         var decoded = try server.decryptAndVerifyRemainingPacket(&buffer, sequenceNumber: 0)
         XCTAssertEqual(message, try decoded.readSSHMessage())


### PR DESCRIPTION
Motivation:
I think there is a bit of a mix of responsibilities between TransportProtection and PacketSerializer. PacketSerializer is responsible for writing out plaintext packet structure, but encrypted packet structure is written out by the TransportProtection implementations. This means that we will have duplicate implementations of basic packet writing logic, every implementation of TP will have to write length, padding length, payload and padding. Also, right now this API uses EncryptablePayload, which we cannot make fully public and accessible for writing tests as it will mean making all SSHMessages public as well.

Modifications:
 - Extract packet writing logic to a separate function that will be used by both plaintext and ciphertext modes
 - Removes usage of EncryptablePayload
 - Write plaintext packet structure (including payload) in the parser
 - TransportProtection implementations now only have to encrypt and tag