### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
+++ b/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
@@ -35,7 +35,7 @@ final class SSHEncryptedTrafficTests: XCTestCase {
         self.parser = nil
     }
 
-    private func assertPacketRoundTrips(_ message: SSHMessage, file: StaticString = #file, line: UInt = #line) {
+    private func assertPacketRoundTrips(_ message: SSHMessage, file: StaticString = #filePath, line: UInt = #line) {
         self.buffer.clear()
         XCTAssertNoThrow(try self.serializer.serialize(message: message, to: &self.buffer), file: file, line: line)
         self.parser.append(bytes: &self.buffer)
@@ -46,7 +46,7 @@ final class SSHEncryptedTrafficTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertNil(try self.parser.nextPacket(), file: file, line: line), file: file, line: line)
     }
 
-    private func assertPacketRoundTripsDripFed(_ message: SSHMessage, file: StaticString = #file, line: UInt = #line) {
+    private func assertPacketRoundTripsDripFed(_ message: SSHMessage, file: StaticString = #filePath, line: UInt = #line) {
         self.buffer.clear()
         XCTAssertNoThrow(try self.serializer.serialize(message: message, to: &self.buffer), file: file, line: line)
 
@@ -67,7 +67,7 @@ final class SSHEncryptedTrafficTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertNil(try self.parser.nextPacket(), file: file, line: line), file: file, line: line)
     }
 
-    private func assertPacketErrors(_ message: SSHMessage, file: StaticString = #file, line: UInt = #line) {
+    private func assertPacketErrors(_ message: SSHMessage, file: StaticString = #filePath, line: UInt = #line) {
         self.buffer.clear()
         XCTAssertNoThrow(try self.serializer.serialize(message: .serviceRequest(.init(service: "some service")), to: &self.buffer))
         self.parser.append(bytes: &self.buffer)

--- a/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
@@ -132,7 +132,7 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
         }
     }
 
-    private func assertUnexpectedMessage<T>(file: StaticString = #file, line: UInt = #line, _ messageFactory: () throws -> T) {
+    private func assertUnexpectedMessage<T>(file: StaticString = #filePath, line: UInt = #line, _ messageFactory: () throws -> T) {
         XCTAssertThrowsError(try messageFactory(), file: file, line: line) { error in
             XCTAssertEqual(error as? SSHKeyExchangeStateMachine.SSHKeyExchangeError, SSHKeyExchangeStateMachine.SSHKeyExchangeError.unexpectedMessage, file: file, line: line)
         }
@@ -1019,7 +1019,7 @@ extension SSHKeyExchangeStateMachineTests {
                                                          allowedStages: SSHKeyExchangeStateMachineTests.HandshakeStages,
                                                          currentStage: SSHKeyExchangeStateMachineTests.HandshakeStages,
                                                          stateMachine: inout SSHKeyExchangeStateMachine,
-                                                         file: StaticString = #file,
+                                                         file: StaticString = #filePath,
                                                          line: UInt = #line) throws {
         if allowedStages.contains(currentStage) {
             // If this stage is allowed, don't try to send the message. Assume it's covered in the mainline.

--- a/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
+++ b/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
@@ -18,7 +18,7 @@ import NIOCore
 import XCTest
 
 final class SSHPacketSerializerTests: XCTestCase {
-    private func runVersionHandshake(serializer: inout SSHPacketSerializer, parser: inout SSHPacketParser, file: StaticString = #file, line: UInt = #line) {
+    private func runVersionHandshake(serializer: inout SSHPacketSerializer, parser: inout SSHPacketParser, file: StaticString = #filePath, line: UInt = #line) {
         var buffer = ByteBufferAllocator().buffer(capacity: 22)
         let versionString = "SSH-2.0-SwiftSSH_1.0"
 

--- a/Tests/NIOSSHTests/SSHPacketParserTests.swift
+++ b/Tests/NIOSSHTests/SSHPacketParserTests.swift
@@ -21,7 +21,7 @@ final class SSHPacketParserTests: XCTestCase {
     /// Feed the SSH version to a packet parser and verify the output.
     ///
     /// Usually used to set up an appropriate state.
-    private func feedVersion(to parser: inout SSHPacketParser, file: StaticString = #file, line: UInt = #line) {
+    private func feedVersion(to parser: inout SSHPacketParser, file: StaticString = #filePath, line: UInt = #line) {
         var version = ByteBuffer.of(string: "SSH-2.0-OpenSSH_7.9\r\n")
         parser.append(bytes: &version)
 

--- a/Tests/NIOSSHTests/Utilities.swift
+++ b/Tests/NIOSSHTests/Utilities.swift
@@ -17,7 +17,7 @@ import NIOCore
 @testable import NIOSSH
 import XCTest
 
-func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = #file, line: UInt = #line) throws -> T {
+func assertNoThrowWithValue<T>(_ body: @autoclosure () throws -> T, defaultValue: T? = nil, message: String? = nil, file: StaticString = #filePath, line: UInt = #line) throws -> T {
     do {
         return try body()
     } catch {


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere

Modifications:

Changed #file to #filePath or #fileID depending on the situation