### PR TITLE
Remove some data-path CoW

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/States/ActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/ActiveState.swift
@@ -57,6 +57,10 @@ extension SSHConnectionStateMachine {
             self.protectionSchemes = previous.protectionSchemes
             self.sessionIdentifier = previous.sessionIdentifier
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/KeyExchangeState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/KeyExchangeState.swift
@@ -41,6 +41,10 @@ extension SSHConnectionStateMachine {
             self.protectionSchemes = state.protectionSchemes
             self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: state.role, remoteVersion: remoteVersion, protectionSchemes: state.protectionSchemes, previousSessionIdentifier: nil)
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/ReceivedKexInitWhenActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/ReceivedKexInitWhenActiveState.swift
@@ -43,6 +43,10 @@ extension SSHConnectionStateMachine {
             self.sessionIdentifier = previous.sessionIdentifier
             self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: previous.role, remoteVersion: previous.remoteVersion, protectionSchemes: previous.protectionSchemes, previousSessionIdentifier: self.sessionIdentifier)
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/ReceivedNewKeysState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/ReceivedNewKeysState.swift
@@ -54,6 +54,10 @@ extension SSHConnectionStateMachine {
                                                                        loop: loop,
                                                                        sessionID: self.sessionIdentifier)
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/RekeyingReceivedNewKeysState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/RekeyingReceivedNewKeysState.swift
@@ -45,6 +45,10 @@ extension SSHConnectionStateMachine {
             self.sessionIdentifier = previousState.sessionIdentifier
             self.keyExchangeStateMachine = previousState.keyExchangeStateMachine
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/RekeyingSentNewKeysState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/RekeyingSentNewKeysState.swift
@@ -45,6 +45,10 @@ extension SSHConnectionStateMachine {
             self.sessionIdentifier = previousState.sessionIdentifier
             self.keyExchangeStateMachine = previousState.keyExchangeStateMachine
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/RekeyingState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/RekeyingState.swift
@@ -54,6 +54,10 @@ extension SSHConnectionStateMachine {
             self.sessionIdentifier = previousState.sessionIdentitifier
             self.keyExchangeStateMachine = previousState.keyExchangeStateMachine
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/SentKexInitWhenActiveState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentKexInitWhenActiveState.swift
@@ -43,6 +43,10 @@ extension SSHConnectionStateMachine {
             self.sessionIdentitifier = previous.sessionIdentifier
             self.keyExchangeStateMachine = SSHKeyExchangeStateMachine(allocator: allocator, loop: loop, role: self.role, remoteVersion: self.remoteVersion, protectionSchemes: self.protectionSchemes, previousSessionIdentifier: previous.sessionIdentifier)
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/SentNewKeysState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentNewKeysState.swift
@@ -54,6 +54,10 @@ extension SSHConnectionStateMachine {
                                                                        loop: loop,
                                                                        sessionID: self.sessionIdentifier)
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
@@ -38,6 +38,10 @@ extension SSHConnectionStateMachine {
             self.parser = SSHPacketParser(allocator: allocator)
             self.allocator = allocator
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/Sources/NIOSSH/Connection State Machine/States/UserAuthenticationState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/UserAuthenticationState.swift
@@ -54,6 +54,10 @@ extension SSHConnectionStateMachine {
             self.protectionSchemes = state.protectionSchemes
             self.sessionIdentifier = state.sessionIdentifier
         }
+
+        mutating func bufferInboundData(_ data: inout ByteBuffer) {
+            self.parser.append(bytes: &data)
+        }
     }
 }
 

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -12,9 +12,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.7
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=267850
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1100050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=65100
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=255850
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1068050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=61100
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
 

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=255850
       - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1068050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=61100
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=61050
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
 

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -11,9 +11,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=261850
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1087050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=63100
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=249850
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1055050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=59050
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,9 +11,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=261850
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1087050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=63100
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=249850
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1055050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=59050
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors


### PR DESCRIPTION
Motivation

CoW on the datapath is really gnarly, and we'd like to avoid it if at all possible.

Modifications

- Move some methods into mutating funcs on the state enum, which lets the compiler elide a retain/release pair that force a CoW
- Add proper reset code to a function that throws to ensure that the compiler can see that the state is always restored afterward.

Results

Drastically lowered allocation count