### PR TITLE
Add Android support

### DIFF
--- a/Sources/NIOSSHClient/InteractivePasswordPromptDelegate.swift
+++ b/Sources/NIOSSHClient/InteractivePasswordPromptDelegate.swift
@@ -45,7 +45,7 @@ final class InteractivePasswordPromptDelegate: NIOSSHClientUserAuthenticationDel
             }
 
             if self.password == nil {
-                #if os(Windows)
+                #if os(Windows) || os(Android)
                 print("Password: ", terminator: "")
                 self.password = readLine() ?? ""
                 #else


### PR DESCRIPTION
Android doesn't have `getpass()` either.

@Joannis, submitted as you asked for.