### PR TITLE
Update allocation limits for main vs 5.8

### DIFF
--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,9 +11,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=217800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=995050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=49000
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=223800
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1005050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=51000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors


### PR DESCRIPTION
Swift appears to have regressed allocations in the nightlies. I don't know why yet, but for now let's get CI working again.