### PR TITLE
Crash in `SSHChildChannel`

### DIFF
--- a/Sources/NIOSSHClient/SimpleCLIParser.swift
+++ b/Sources/NIOSSHClient/SimpleCLIParser.swift
@@ -16,42 +16,7 @@ import Foundation
 /// A very simple CLI parser.
 struct SimpleCLIParser {
     func parse() -> Result {
-        var arguments = CommandLine.arguments.dropFirst()
-
-        // Let's start by searching for flags
-        var listen: Listen?
-        while let first = arguments.first, first.starts(with: "-") {
-            arguments = arguments.dropFirst()
-
-            switch first {
-            case "-L":
-                // The next argument is the listen string.
-                guard let next = arguments.popFirst(), let parsed = Listen(listenString: next) else {
-                    self.usage()
-                }
-                listen = parsed
-            default:
-                self.usage()
-            }
-        }
-
-        // The first argument must be "target"
-        guard var target = arguments.popFirst() else {
-            self.usage()
-        }
-
-        // We trick Foundation into doing something sensible here by prepending the target with ssh:// if it didn't
-        // already have it.
-        if !target.starts(with: "ssh://") {
-            target = "ssh://" + target
-        }
-
-        guard let targetURL = URL(string: target) else {
-            self.usage()
-        }
-        let command = arguments.joined(separator: " ")
-
-        return Result(commandString: command, target: targetURL, listen: listen)
+        Result()
     }
 
     private func usage() -> Never {
@@ -74,13 +39,13 @@ extension SimpleCLIParser {
 
         var listen: Listen?
 
-        fileprivate init(commandString: String?, target: URL, listen: Listen?) {
-            self.commandString = commandString ?? "uname -a"
-            self.host = target.host ?? "::1"
-            self.port = target.port ?? 22
-            self.user = target.user
-            self.password = target.password
-            self.listen = listen
+        fileprivate init() {
+            self.commandString = "yes \"long text\" | head -n 1000000\n"
+            self.host = "localhost"
+            self.port = 2223
+            self.user = "username"
+            self.password = "password"
+            self.listen = nil
         }
     }
 }

--- a/Sources/NIOSSHClient/main.swift
+++ b/Sources/NIOSSHClient/main.swift
@@ -101,6 +101,11 @@ if let listen = parseResult.listen {
             guard channelType == .session else {
                 return channel.eventLoop.makeFailedFuture(SSHClientError.invalidChannelType)
             }
+            // $$$ Force closing
+            DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + 1) {
+                print("❌")
+                _ = childChannel.close(promise: nil)
+            }
             return childChannel.pipeline.addHandlers([ExampleExecHandler(command: parseResult.commandString, completePromise: exitStatusPromise), ErrorHandler()])
         }
         return promise.futureResult

--- a/docker/ssh-docker-compose.yaml
+++ b/docker/ssh-docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.7"
+
+services:
+  ssh:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: openssh-server
+    hostname: openssh-server
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+      - SUDO_ACCESS=false
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=password
+      - USER_NAME=username
+    ports:
+      - 2223:2222
+    restart: unless-stopped


### PR DESCRIPTION
SwiftNIO SSH commit hash: c56ababb0e22e0cdf5ec8b31698e07f943ea92e7

## Context

While writing Xcode tests in one of my project which uses `swift-nio-ssh`, I encountered a crash.
I reproduced it using the `NIOSSHClient` target.

- I noticed the crash only appears when using a command which produces a long output such as `yes \"long text\" | head -n 1000000\n`
- I only reproduced it when exchanging to the linked docker container. I used it in my automate tests.

## Steps to reproduce
1. Launch the ssh server: `docker-compose -f ./docker/ssh-docker-compose.yaml up -d`
2. Run the modified `NIOSSHClient` target. 
3. Observe the crash in Xcode
```
* thread #2, name = 'NIO-ELT-0-#0', stop reason = Fatal error: Sent channel window adjust on channel in invalid state
    frame #0: 0x0000000193fe4ae8 libswiftCore.dylib`_swift_runtime_on_report
    frame #1: 0x00000001940825d4 libswiftCore.dylib`_swift_stdlib_reportFatalErrorInFile + 208
    frame #2: 0x0000000193c614b4 libswiftCore.dylib`closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in closure #1 (Swift.UnsafeBufferPointer<Swift.UInt8>) -> () in Swift._assertionFailure(_: Swift.StaticString, _: Swift.String, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 196
    frame #3: 0x0000000193c60210 libswiftCore.dylib`Swift._assertionFailure(_: Swift.StaticString, _: Swift.String, file: Swift.StaticString, line: Swift.UInt, flags: Swift.UInt32) -> Swift.Never + 308
  * frame #4: 0x00000001002cae7c NIOSSHClient`ChildChannelStateMachine.sendChannelWindowAdjust(message=(recipientChannel = 0, bytesToAdd = 8811376), self=NIOSSH.ChildChannelStateMachine @ 0x0000000101e040a8) at ChildChannelStateMachine.swift:432:13
...
```
## Configuration
$ swift --version
swift-driver version: 1.75.2 Apple Swift version 5.8 (swiftlang-5.8.0.124.2 clang-1403.0.22.11.100)
Target: arm64-apple-macosx13.0

Operating system:  macOS Ventura 13.2

Xcode version: 14.2

$ uname -a
Darwin MBP-de-Gaetan-Zanella 22.3.0 Darwin Kernel Version 22.3.0: Thu Jan  5 20:48:54 PST 2023; root:xnu-8792.81.2~2/RELEASE_ARM64_T6000 arm64