### PR TITLE
Avoid sending window update messages if locally closed (#143)

### DIFF
--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -647,7 +647,7 @@ private extension SSHChildChannel {
         switch data {
         case .data(let data):
             // We only futz with the window manager if the channel is not already closed.
-            if !self.didClose, let increment = self.windowManager.unbufferBytes(data.data.readableBytes) {
+            if !self.didClose, !self.state.sentClose, let increment = self.windowManager.unbufferBytes(data.data.readableBytes) {
                 let update = SSHMessage.ChannelWindowAdjustMessage(recipientChannel: self.state.remoteChannelIdentifier!, bytesToAdd: UInt32(increment))
                 self.processOutboundMessage(.channelWindowAdjust(update), promise: nil)
             }


### PR DESCRIPTION
Motivation:

Currently the library crashes if a window update is required and the connection is closed locally.

Modifications:

Check the connection state before sending a window update message.