### PR TITLE
Update update-alloc-limits-to-last-completed-ci-build

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio-ssh-"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 55 56 57 58 nightly; do
+for f in 56 57 58 59 nightly; do
     echo "swift$f"
     if [[ "$f" == "nightly" ]]; then
         url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -14,9 +14,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=223800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1005050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=51000
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=217800
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=995050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=49000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors


### PR DESCRIPTION
Update to drop 55 support and add 59