### PR TITLE
Update allocation limits

### DIFF
--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio-ssh:20.04-5.6
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=235850
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1040050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1042050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=55050
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio-ssh:22.04-5.7
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=223800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1008050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1010050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=51000
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio-ssh:22.04-5.8
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=217800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=995050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=997050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=49000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -15,7 +15,7 @@ services:
     image: swift-nio-ssh:22.04-5.9
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=223800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1005050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1007050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=51000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -15,7 +15,7 @@ services:
     image: swift-nio-ssh:22.04-main
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=217800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=995050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=997050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=49000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread


### PR DESCRIPTION
Allocations regressed due to our use of EmbeddedChannel, which now uses a new atomic since apple/swift-nio#2429. We can update the limits accordingly.