### PR TITLE
Update allocation counters

### DIFF
--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio-ssh:22.04-5.8
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=217800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=997050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=998050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=49000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -15,7 +15,7 @@ services:
     image: swift-nio-ssh:22.04-5.9
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=223800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1007050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1008050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=51000
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread


### PR DESCRIPTION
Allocations have regressed without any code change. Likely cause is either swift (5.9 is still under development and I think 5.8 got a patch release) or one of our dependencies (swift-nio, swift-crypto, swift-atomics). We need to investigate why in the future.