### PR TITLE
Fixes client mode version parsing

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
@@ -35,7 +35,7 @@ extension SSHConnectionStateMachine {
             self.serializer = state.serializer
             self.protectionSchemes = state.protectionSchemes
 
-            self.parser = SSHPacketParser(allocator: allocator)
+            self.parser = SSHPacketParser(isServer: self.role.isServer, allocator: allocator)
             self.allocator = allocator
         }
 

--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -48,7 +48,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
             DispatchQueue(label: "pipe bootstrap").async {
                 bootstrap.channelOption(ChannelOptions.allowRemoteHalfClosure, value: true).channelInitializer { channel in
                     channel.pipeline.addHandler(theirs)
-                }.withPipes(inputDescriptor: 0, outputDescriptor: 1).whenComplete { result in
+                }.takingOwnershipOfDescriptors(input: 0, output: 1).whenComplete { result in
                     switch result {
                     case .success:
                         // We need to exec a thing.

--- a/Sources/NIOSSHServer/ExecHandler.swift
+++ b/Sources/NIOSSHServer/ExecHandler.swift
@@ -120,7 +120,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
                     .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
                     .channelInitializer { pipeChannel in
                         pipeChannel.pipeline.addHandler(theirs)
-                    }.withPipes(inputDescriptor: dup(outPipe.fileHandleForReading.fileDescriptor), outputDescriptor: dup(inPipe.fileHandleForWriting.fileDescriptor)).wait()
+                    }.takingOwnershipOfDescriptors(input: dup(outPipe.fileHandleForReading.fileDescriptor), output: dup(inPipe.fileHandleForWriting.fileDescriptor)).wait()
 
                 // Ok, great, we've sorted stdout and stdin. For stderr we need a different strategy: we just park a thread for this.
                 DispatchQueue(label: "stderrorwhatever").async {

--- a/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
+++ b/Tests/NIOSSHTests/SSHEncryptedTrafficTests.swift
@@ -25,7 +25,7 @@ final class SSHEncryptedTrafficTests: XCTestCase {
 
     override func setUp() {
         self.serializer = SSHPacketSerializer()
-        self.parser = SSHPacketParser(allocator: .init())
+        self.parser = SSHPacketParser(isServer: false, allocator: .init())
 
         self.assertPacketRoundTrips(.version("SSH-2.0-SwiftSSH_1.0"))
     }

--- a/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
+++ b/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
@@ -51,7 +51,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.disconnect(.init(reason: 42, description: "description", tag: "tag"))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -74,7 +74,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.serviceRequest(.init(service: "ssh-userauth"))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -97,7 +97,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.serviceAccept(.init(service: "ssh-userauth"))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -133,7 +133,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         ))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -165,7 +165,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.keyExchangeInit(.init(publicKey: ByteBuffer.of(bytes: [42])))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -193,7 +193,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         ))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -226,7 +226,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.newKeys
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 
@@ -247,7 +247,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         let message = SSHMessage.newKeys
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
-        var parser = SSHPacketParser(allocator: allocator)
+        var parser = SSHPacketParser(isServer: false, allocator: allocator)
 
         self.runVersionHandshake(serializer: &serializer, parser: &parser)
 


### PR DESCRIPTION
Motivation:
Server may send additional lines of data before version, but since we use version as part of key exchange, we need to filter out those lines, otherwise it will fail key exchange.

Modifications:
 - Strip out lines of data before version in client role
 - Update tests