### PR TITLE
Separate public/private keys and signatures into protocol conformances

### DIFF
--- a/Sources/NIOSSH/Keys And Signatures/CryptoKit+PrivateKeyProtocols.swift
+++ b/Sources/NIOSSH/Keys And Signatures/CryptoKit+PrivateKeyProtocols.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+import CryptoKit
+
+struct Curve25519Signature: NIOSSHSignatureProtocol {
+    static let signaturePrefix = "ssh-ed25519"
+
+    let rawRepresentation: Data
+
+    func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeEd25519Signature(signature: self)
+    }
+
+    static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard var rawRepresentation = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHSignature
+        }
+
+        return Self(rawRepresentation: rawRepresentation.readData(length: rawRepresentation.readableBytes)!)
+    }
+}
+
+extension Curve25519.Signing.PrivateKey: NIOSSHPrivateKeyProtocol {
+    public static var keyPrefix: String { "ssh-ed25519" }
+    
+    public var sshPublicKey: NIOSSHPublicKeyProtocol { publicKey }
+
+    public func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        return try Curve25519Signature(rawRepresentation: self.signature(for: data))
+    }
+}
+
+extension P256.Signing.ECDSASignature: NIOSSHSignatureProtocol {
+    public static var signaturePrefix: String { "ecdsa-sha2-nistp256" }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP256Signature(baseSignature: self)
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let rawRepresentation = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHSignature
+        }
+
+        return try Self(rawRepresentation: rawRepresentation.readableBytesView)
+    }
+}
+
+extension P256.Signing.PrivateKey: NIOSSHPrivateKeyProtocol {
+    public static var keyPrefix: String { "ecdsa-sha2-nistp256" }
+    
+    public var sshPublicKey: NIOSSHPublicKeyProtocol { publicKey }
+
+    public func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        let signature: P256.Signing.ECDSASignature = try self.signature(for: data)
+        return signature
+    }
+}
+
+extension P384.Signing.ECDSASignature: NIOSSHSignatureProtocol {
+    public static var signaturePrefix: String { "ecdsa-sha2-nistp384" }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP384Signature(baseSignature: self)
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let rawRepresentation = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHSignature
+        }
+
+        return try Self(rawRepresentation: rawRepresentation.readableBytesView)
+    }
+}
+
+extension P384.Signing.PrivateKey: NIOSSHPrivateKeyProtocol {
+    public static var keyPrefix: String { "ecdsa-sha2-nistp384" }
+    
+    public var sshPublicKey: NIOSSHPublicKeyProtocol { publicKey }
+
+    public func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        let signature: P384.Signing.ECDSASignature = try self.signature(for: data)
+        return signature
+    }
+}
+
+extension P521.Signing.ECDSASignature: NIOSSHSignatureProtocol {
+    public static var signaturePrefix: String { "ecdsa-sha2-nistp521" }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP521Signature(baseSignature: self)
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self {
+        guard let rawRepresentation = buffer.readSSHString() else {
+            throw NIOSSHError.invalidSSHSignature
+        }
+
+        return try Self(rawRepresentation: rawRepresentation.readableBytesView)
+    }
+}
+
+extension P521.Signing.PrivateKey: NIOSSHPrivateKeyProtocol {
+    public static var keyPrefix: String {
+        "ecdsa-sha2-nistp521"
+    }
+    
+    public var sshPublicKey: NIOSSHPublicKeyProtocol { publicKey }
+
+    public func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        let signature: P521.Signing.ECDSASignature = try self.signature(for: data)
+        return signature
+    }
+}
+
+#if canImport(Darwin)
+extension SecureEnclave.P256.Signing.PrivateKey: NIOSSHPrivateKeyProtocol {
+    public static var keyPrefix: String { P256.Signing.PrivateKey.keyPrefix }
+    
+    public var sshPublicKey: NIOSSHPublicKeyProtocol { publicKey }
+
+    public func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol {
+        let signature: P256.Signing.ECDSASignature = try self.signature(for: data)
+        return signature
+    }
+}
+#endif

--- a/Sources/NIOSSH/Keys And Signatures/CryptoKit+PublicKeyProtocols.swift
+++ b/Sources/NIOSSH/Keys And Signatures/CryptoKit+PublicKeyProtocols.swift
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+import CryptoKit
+
+extension Curve25519.Signing.PublicKey: NIOSSHPublicKeyProtocol {
+    internal static var prefix: String { "ssh-ed25519" }
+    public static var publicKeyPrefix: String? { Self.prefix }
+    public var publicKeyPrefix: String { Self.prefix }
+
+    public func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool {
+        guard let signature = signature.backingSignature as? Curve25519Signature else {
+            return false
+        }
+
+        return self.isValidSignature(signature.rawRepresentation, for: data)
+    }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeEd25519PublicKey(baseKey: self)
+    }
+
+    public func writeHostKey(to buffer: inout ByteBuffer) -> Int {
+        var writtenBytes = 0
+        writtenBytes += buffer.writeSSHString(self.publicKeyPrefix.utf8)
+        writtenBytes += self.write(to: &buffer)
+        return writtenBytes
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self? {
+        guard let qBytes = buffer.readSSHString() else {
+            return nil
+        }
+
+        return try Curve25519.Signing.PublicKey(rawRepresentation: qBytes.readableBytesView)
+    }
+}
+
+extension P256.Signing.PublicKey: NIOSSHPublicKeyProtocol {
+    internal static var prefix: String { "ecdsa-sha2-nistp256" }
+    public static var publicKeyPrefix: String? { Self.prefix }
+    public var publicKeyPrefix: String { Self.prefix }
+
+    public func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool {
+        guard let signature = signature.backingSignature as? P256.Signing.ECDSASignature else {
+            return false
+        }
+
+        return self.isValidSignature(signature, for: data)
+    }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP256PublicKey(baseKey: self)
+    }
+
+    public func writeHostKey(to buffer: inout ByteBuffer) -> Int {
+        var writtenBytes = 0
+        writtenBytes += buffer.writeSSHString(self.publicKeyPrefix.utf8)
+        writtenBytes += self.write(to: &buffer)
+        return writtenBytes
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self? {
+        // For ECDSA-P256, the key format is the string "nistp256" followed by the
+        // the public point Q.
+        guard var domainParameter = buffer.readSSHString() else {
+            return nil
+        }
+        guard domainParameter.readableBytesView.elementsEqual("nistp256".utf8) else {
+            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
+            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
+        }
+
+        guard let qBytes = buffer.readSSHString() else {
+            return nil
+        }
+
+        return try P256.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
+    }
+}
+
+extension P384.Signing.PublicKey: NIOSSHPublicKeyProtocol {
+    internal static var prefix: String { "ecdsa-sha2-nistp384" }
+    public static var publicKeyPrefix: String? { Self.prefix }
+    public var publicKeyPrefix: String { Self.prefix }
+
+    public func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool {
+        guard let signature = signature.backingSignature as? P384.Signing.ECDSASignature else {
+            return false
+        }
+        
+        return self.isValidSignature(signature, for: data)
+    }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP384PublicKey(baseKey: self)
+    }
+
+    public func writeHostKey(to buffer: inout ByteBuffer) -> Int {
+        var writtenBytes = 0
+        writtenBytes += buffer.writeSSHString(self.publicKeyPrefix.utf8)
+        writtenBytes += self.write(to: &buffer)
+        return writtenBytes
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self? {
+        // For ECDSA-P384, the key format is the string "nistp384" followed by the
+        // the public point Q.
+        guard var domainParameter = buffer.readSSHString() else {
+            return nil
+        }
+        guard domainParameter.readableBytesView.elementsEqual("nistp384".utf8) else {
+            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
+            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
+        }
+
+        guard let qBytes = buffer.readSSHString() else {
+            return nil
+        }
+
+        return try P384.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
+    }
+}
+
+extension P521.Signing.PublicKey: NIOSSHPublicKeyProtocol {
+    internal static var prefix: String { "ecdsa-sha2-nistp521" }
+    public static var publicKeyPrefix: String? { Self.prefix }
+    public var publicKeyPrefix: String { Self.prefix }
+
+    public func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool {
+        guard let signature = signature.backingSignature as? P521.Signing.ECDSASignature else {
+            return false
+        }
+        
+        return self.isValidSignature(signature, for: data)
+    }
+
+    public func write(to buffer: inout ByteBuffer) -> Int {
+        buffer.writeECDSAP521PublicKey(baseKey: self)
+    }
+
+    public func writeHostKey(to buffer: inout ByteBuffer) -> Int {
+        var writtenBytes = 0
+        writtenBytes += buffer.writeSSHString(self.publicKeyPrefix.utf8)
+        writtenBytes += self.write(to: &buffer)
+        return writtenBytes
+    }
+
+    public static func read(from buffer: inout ByteBuffer) throws -> Self? {
+        // For ECDSA-P521, the key format is the string "nistp521" followed by the
+        // the public point Q.
+        guard var domainParameter = buffer.readSSHString() else {
+            return nil
+        }
+        guard domainParameter.readableBytesView.elementsEqual("nistp521".utf8) else {
+            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
+            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
+        }
+
+        guard let qBytes = buffer.readSSHString() else {
+            return nil
+        }
+
+        return try P521.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
+    }
+}

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKeyProtocol.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKeyProtocol.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+
+public protocol NIOSSHPrivateKeyProtocol: Sendable {
+    /// An identifier that represents the type of private key used in an SSH packet.
+    /// This identifier MUST be unique to the private key implementation.
+    /// The returned value MUST NOT overlap with other private key implementations or a specifications that the private key does not implement.
+    static var keyPrefix: String { get }
+
+    /// A public key instance that is able to verify signatures that are created using this private key.
+    var sshPublicKey: NIOSSHPublicKeyProtocol { get }
+
+    /// Creates a signature, proving that `data` has been sent by the holder of this private key, and can be verified by `publicKey`.
+    func sshSignature<D: DataProtocol>(for data: D) throws -> NIOSSHSignatureProtocol
+}
+
+internal extension NIOSSHPrivateKeyProtocol {
+    var keyPrefix: String {
+        Self.keyPrefix
+    }
+}

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -25,9 +25,9 @@ import NIOCore
 /// This key is not capable of signing, only verifying.
 public struct NIOSSHPublicKey: Sendable, Hashable {
     /// The actual key structure used to perform the key operations.
-    internal var backingKey: BackingKey
+    internal var backingKey: NIOSSHPublicKeyProtocol
 
-    internal init(backingKey: BackingKey) {
+    internal init(backingKey: NIOSSHPublicKeyProtocol) {
         self.backingKey = backingKey
     }
 
@@ -56,12 +56,14 @@ public struct NIOSSHPublicKey: Sendable, Hashable {
         self = key
     }
 
-    /// Encapsulate a ``NIOSSHCertifiedPublicKey`` in a ``NIOSSHPublicKey``.
-    ///
-    /// This initializer can be used to "wrap" a ``NIOSSHCertifiedPublicKey`` into the interface of ``NIOSSHPublicKey``.
-    /// It is typically used in cases where the fact that the key is certified is not relevant.
-    public init(_ certifiedKey: NIOSSHCertifiedPublicKey) {
-        self.backingKey = .certified(certifiedKey)
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.backingKey.publicKeyPrefix)
+        hasher.combine(self.backingKey.rawRepresentation)
+    }
+
+    public static func == (lhs: NIOSSHPublicKey, rhs: NIOSSHPublicKey) -> Bool {
+        lhs.backingKey.publicKeyPrefix == rhs.backingKey.publicKeyPrefix &&
+        lhs.backingKey.rawRepresentation == rhs.backingKey.rawRepresentation
     }
 }
 
@@ -69,168 +71,36 @@ extension NIOSSHPublicKey {
     /// Verifies that a given `NIOSSHSignature` was created by the holder of the private key associated with this
     /// public key.
     internal func isValidSignature<DigestBytes: Digest>(_ signature: NIOSSHSignature, for digest: DigestBytes) -> Bool {
-        switch (self.backingKey, signature.backingSignature) {
-        case (.ed25519(let key), .ed25519(let sig)):
-            return digest.withUnsafeBytes { digestPtr in
-                switch sig {
-                case .byteBuffer(let buf):
-                    return key.isValidSignature(buf.readableBytesView, for: digestPtr)
-                case .data(let d):
-                    return key.isValidSignature(d, for: digestPtr)
-                }
-            }
-        case (.ecdsaP256(let key), .ecdsaP256(let sig)):
-            return digest.withUnsafeBytes { digestPtr in
-                key.isValidSignature(sig, for: digestPtr)
-            }
-        case (.ecdsaP384(let key), .ecdsaP384(let sig)):
-            return digest.withUnsafeBytes { digestPtr in
-                key.isValidSignature(sig, for: digestPtr)
-            }
-        case (.ecdsaP521(let key), .ecdsaP521(let sig)):
-            return digest.withUnsafeBytes { digestPtr in
-                key.isValidSignature(sig, for: digestPtr)
-            }
-        case (.certified(let key), _):
-            return key.isValidSignature(signature, for: digest)
-        case (.ed25519, _),
-             (.ecdsaP256, _),
-             (.ecdsaP384, _),
-             (.ecdsaP521, _):
-            return false
+        digest.withUnsafeBytes { digestptr in
+            self.backingKey.isValidSignature(signature, for: digestptr)
         }
+    }
+
+    internal func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool {
+        self.backingKey.isValidSignature(signature, for: data)
     }
 
     internal func isValidSignature(_ signature: NIOSSHSignature, for bytes: ByteBuffer) -> Bool {
-        switch (self.backingKey, signature.backingSignature) {
-        case (.ed25519(let key), .ed25519(.byteBuffer(let buf))):
-            return key.isValidSignature(buf.readableBytesView, for: bytes.readableBytesView)
-        case (.ed25519(let key), .ed25519(.data(let buf))):
-            return key.isValidSignature(buf, for: bytes.readableBytesView)
-        case (.ecdsaP256(let key), .ecdsaP256(let sig)):
-            return key.isValidSignature(sig, for: bytes.readableBytesView)
-        case (.ecdsaP384(let key), .ecdsaP384(let sig)):
-            return key.isValidSignature(sig, for: bytes.readableBytesView)
-        case (.ecdsaP521(let key), .ecdsaP521(let sig)):
-            return key.isValidSignature(sig, for: bytes.readableBytesView)
-        case (.certified(let key), _):
-            return key.isValidSignature(signature, for: bytes)
-        case (.ed25519, _),
-             (.ecdsaP256, _),
-             (.ecdsaP384, _),
-             (.ecdsaP521, _):
-            return false
-        }
+        return backingKey.isValidSignature(signature, for: bytes.readableBytesView)
     }
 
     internal func isValidSignature(_ signature: NIOSSHSignature, for payload: UserAuthSignablePayload) -> Bool {
-        switch (self.backingKey, signature.backingSignature) {
-        case (.ed25519(let key), .ed25519(.byteBuffer(let sig))):
-            return key.isValidSignature(sig.readableBytesView, for: payload.bytes.readableBytesView)
-        case (.ed25519(let key), .ed25519(.data(let sig))):
-            return key.isValidSignature(sig, for: payload.bytes.readableBytesView)
-        case (.ecdsaP256(let key), .ecdsaP256(let sig)):
-            return key.isValidSignature(sig, for: payload.bytes.readableBytesView)
-        case (.ecdsaP384(let key), .ecdsaP384(let sig)):
-            return key.isValidSignature(sig, for: payload.bytes.readableBytesView)
-        case (.ecdsaP521(let key), .ecdsaP521(let sig)):
-            return key.isValidSignature(sig, for: payload.bytes.readableBytesView)
-        case (.certified(let key), _):
-            return key.isValidSignature(signature, for: payload)
-        case (.ed25519, _),
-             (.ecdsaP256, _),
-             (.ecdsaP384, _),
-             (.ecdsaP521, _):
-            return false
-        }
+        return backingKey.isValidSignature(signature, for: payload.bytes.readableBytesView)
     }
 }
 
 extension NIOSSHPublicKey {
-    /// The various key types that can be used with NIOSSH.
-    internal enum BackingKey {
-        case ed25519(Curve25519.Signing.PublicKey)
-        case ecdsaP256(P256.Signing.PublicKey)
-        case ecdsaP384(P384.Signing.PublicKey)
-        case ecdsaP521(P521.Signing.PublicKey)
-        case certified(NIOSSHCertifiedPublicKey) // This case recursively contains `NIOSSHPublicKey`.
-    }
-
-    /// The prefix of an Ed25519 public key.
-    internal static let ed25519PublicKeyPrefix = "ssh-ed25519".utf8
-
-    /// The prefix of a P256 ECDSA public key.
-    internal static let ecdsaP256PublicKeyPrefix = "ecdsa-sha2-nistp256".utf8
-
-    /// The prefix of a P384 ECDSA public key.
-    internal static let ecdsaP384PublicKeyPrefix = "ecdsa-sha2-nistp384".utf8
-
-    /// The prefix of a P521 ECDSA public key.
-    internal static let ecdsaP521PublicKeyPrefix = "ecdsa-sha2-nistp521".utf8
-
     internal var keyPrefix: String.UTF8View {
-        switch self.backingKey {
-        case .ed25519:
-            return Self.ed25519PublicKeyPrefix
-        case .ecdsaP256:
-            return Self.ecdsaP256PublicKeyPrefix
-        case .ecdsaP384:
-            return Self.ecdsaP384PublicKeyPrefix
-        case .ecdsaP521:
-            return Self.ecdsaP521PublicKeyPrefix
-        case .certified(let base):
-            return base.keyPrefix
-        }
+        backingKey.publicKeyPrefix.utf8
     }
 
     internal static var knownAlgorithms: [String.UTF8View] {
-        [Self.ed25519PublicKeyPrefix, Self.ecdsaP384PublicKeyPrefix, Self.ecdsaP256PublicKeyPrefix, Self.ecdsaP521PublicKeyPrefix]
-    }
-}
-
-extension NIOSSHPublicKey.BackingKey: Equatable {
-    static func == (lhs: NIOSSHPublicKey.BackingKey, rhs: NIOSSHPublicKey.BackingKey) -> Bool {
-        // We implement equatable in terms of the key representation.
-        switch (lhs, rhs) {
-        case (.ed25519(let lhs), .ed25519(let rhs)):
-            return lhs.rawRepresentation == rhs.rawRepresentation
-        case (.ecdsaP256(let lhs), .ecdsaP256(let rhs)):
-            return lhs.rawRepresentation == rhs.rawRepresentation
-        case (.ecdsaP384(let lhs), .ecdsaP384(let rhs)):
-            return lhs.rawRepresentation == rhs.rawRepresentation
-        case (.ecdsaP521(let lhs), .ecdsaP521(let rhs)):
-            return lhs.rawRepresentation == rhs.rawRepresentation
-        case (.certified(let lhs), .certified(let rhs)):
-            return lhs == rhs
-        case (.ed25519, _),
-             (.ecdsaP256, _),
-             (.ecdsaP384, _),
-             (.ecdsaP521, _),
-             (.certified, _):
-            return false
-        }
-    }
-}
-
-extension NIOSSHPublicKey.BackingKey: Hashable {
-    func hash(into hasher: inout Hasher) {
-        switch self {
-        case .ed25519(let pkey):
-            hasher.combine(1)
-            hasher.combine(pkey.rawRepresentation)
-        case .ecdsaP256(let pkey):
-            hasher.combine(2)
-            hasher.combine(pkey.rawRepresentation)
-        case .ecdsaP384(let pkey):
-            hasher.combine(3)
-            hasher.combine(pkey.rawRepresentation)
-        case .ecdsaP521(let pkey):
-            hasher.combine(4)
-            hasher.combine(pkey.rawRepresentation)
-        case .certified(let pkey):
-            hasher.combine(5)
-            hasher.combine(pkey)
-        }
+        [
+            Curve25519.Signing.PublicKey.prefix.utf8, 
+            P256.Signing.PublicKey.prefix.utf8,
+            P384.Signing.PublicKey.prefix.utf8,
+            P521.Signing.PublicKey.prefix.utf8
+        ]
     }
 }
 
@@ -238,26 +108,7 @@ extension ByteBuffer {
     /// Writes an SSH host key to this `ByteBuffer`.
     @discardableResult
     mutating func writeSSHHostKey(_ key: NIOSSHPublicKey) -> Int {
-        var writtenBytes = 0
-
-        switch key.backingKey {
-        case .ed25519(let key):
-            writtenBytes += self.writeSSHString(NIOSSHPublicKey.ed25519PublicKeyPrefix)
-            writtenBytes += self.writeEd25519PublicKey(baseKey: key)
-        case .ecdsaP256(let key):
-            writtenBytes += self.writeSSHString(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix)
-            writtenBytes += self.writeECDSAP256PublicKey(baseKey: key)
-        case .ecdsaP384(let key):
-            writtenBytes += self.writeSSHString(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix)
-            writtenBytes += self.writeECDSAP384PublicKey(baseKey: key)
-        case .ecdsaP521(let key):
-            writtenBytes += self.writeSSHString(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix)
-            writtenBytes += self.writeECDSAP521PublicKey(baseKey: key)
-        case .certified(let key):
-            return self.writeCertifiedKey(key)
-        }
-
-        return writtenBytes
+        key.backingKey.writeHostKey(to: &self)
     }
 
     /// Writes an SSH host key to this `ByteBuffer`, without a prefix.
@@ -265,18 +116,7 @@ extension ByteBuffer {
     /// This is mostly used as part of the certified key structure.
     @discardableResult
     mutating func writePublicKeyWithoutPrefix(_ key: NIOSSHPublicKey) -> Int {
-        switch key.backingKey {
-        case .ed25519(let key):
-            return self.writeEd25519PublicKey(baseKey: key)
-        case .ecdsaP256(let key):
-            return self.writeECDSAP256PublicKey(baseKey: key)
-        case .ecdsaP384(let key):
-            return self.writeECDSAP384PublicKey(baseKey: key)
-        case .ecdsaP521(let key):
-            return self.writeECDSAP521PublicKey(baseKey: key)
-        case .certified:
-            preconditionFailure("Certified keys are the only callers of this method, and cannot contain themselves")
-        }
+        key.backingKey.write(to: &self)
     }
 
     mutating func readSSHHostKey() throws -> NIOSSHPublicKey? {
@@ -293,27 +133,32 @@ extension ByteBuffer {
 
     mutating func readPublicKeyWithoutPrefixForIdentifier<Bytes: Collection>(_ keyIdentifierBytes: Bytes) throws -> NIOSSHPublicKey? where Bytes.Element == UInt8 {
         try self.rewindOnNilOrError { buffer in
-            if keyIdentifierBytes.elementsEqual(NIOSSHPublicKey.ed25519PublicKeyPrefix) {
-                return try buffer.readEd25519PublicKey()
-            } else if keyIdentifierBytes.elementsEqual(NIOSSHPublicKey.ecdsaP256PublicKeyPrefix) {
-                return try buffer.readECDSAP256PublicKey()
-            } else if keyIdentifierBytes.elementsEqual(NIOSSHPublicKey.ecdsaP384PublicKeyPrefix) {
-                return try buffer.readECDSAP384PublicKey()
-            } else if keyIdentifierBytes.elementsEqual(NIOSSHPublicKey.ecdsaP521PublicKeyPrefix) {
-                return try buffer.readECDSAP521PublicKey()
+            if keyIdentifierBytes.elementsEqual(Curve25519.Signing.PublicKey.prefix.utf8) {
+                return try Curve25519.Signing.PublicKey.read(from: &buffer)
+                    .map(NIOSSHPublicKey.init)
+            } else if keyIdentifierBytes.elementsEqual(P256.Signing.PublicKey.prefix.utf8) {
+                return try P256.Signing.PublicKey.read(from: &buffer)
+                    .map(NIOSSHPublicKey.init)
+            } else if keyIdentifierBytes.elementsEqual(P384.Signing.PublicKey.prefix.utf8) {
+                return try P384.Signing.PublicKey.read(from: &buffer)
+                    .map(NIOSSHPublicKey.init)
+            } else if keyIdentifierBytes.elementsEqual(P521.Signing.PublicKey.prefix.utf8) {
+                return try P521.Signing.PublicKey.read(from: &buffer)
+                    .map(NIOSSHPublicKey.init)
             } else {
                 // We don't know this public key type. Maybe the certified keys do.
-                return try buffer.readCertifiedKeyWithoutKeyPrefix(keyIdentifierBytes).map(NIOSSHPublicKey.init)
+                return try buffer.readCertifiedKeyWithoutKeyPrefix(keyIdentifierBytes)
+                    .map(NIOSSHPublicKey.init)
             }
         }
     }
 
-    private mutating func writeEd25519PublicKey(baseKey: Curve25519.Signing.PublicKey) -> Int {
+    mutating func writeEd25519PublicKey(baseKey: Curve25519.Signing.PublicKey) -> Int {
         // For Ed25519 the key format is  Q as a String.
         self.writeSSHString(baseKey.rawRepresentation)
     }
 
-    private mutating func writeECDSAP256PublicKey(baseKey: P256.Signing.PublicKey) -> Int {
+    mutating func writeECDSAP256PublicKey(baseKey: P256.Signing.PublicKey) -> Int {
         // For ECDSA-P256, the key format is the string "nistp256", followed by the
         // the public point Q.
         var writtenBytes = 0
@@ -322,7 +167,7 @@ extension ByteBuffer {
         return writtenBytes
     }
 
-    private mutating func writeECDSAP384PublicKey(baseKey: P384.Signing.PublicKey) -> Int {
+    mutating func writeECDSAP384PublicKey(baseKey: P384.Signing.PublicKey) -> Int {
         // For ECDSA-P384, the key format is the string "nistp384", followed by the
         // the public point Q.
         var writtenBytes = 0
@@ -331,96 +176,13 @@ extension ByteBuffer {
         return writtenBytes
     }
 
-    private mutating func writeECDSAP521PublicKey(baseKey: P521.Signing.PublicKey) -> Int {
+    mutating func writeECDSAP521PublicKey(baseKey: P521.Signing.PublicKey) -> Int {
         // For ECDSA-P521, the key format is the string "nistp521", followed by the
         // the public point Q.
         var writtenBytes = 0
         writtenBytes += self.writeSSHString("nistp521".utf8)
         writtenBytes += self.writeSSHString(baseKey.x963Representation)
         return writtenBytes
-    }
-
-    /// A helper function that reads an Ed25519 public key.
-    ///
-    /// Not safe to call from arbitrary code as this does not return the reader index on failure: it relies on the caller performing
-    /// the rewind.
-    private mutating func readEd25519PublicKey() throws -> NIOSSHPublicKey? {
-        // For ed25519 the key format is just Q encoded as a String.
-        guard let qBytes = self.readSSHString() else {
-            return nil
-        }
-
-        let key = try Curve25519.Signing.PublicKey(rawRepresentation: qBytes.readableBytesView)
-        return NIOSSHPublicKey(backingKey: .ed25519(key))
-    }
-
-    /// A helper function that reads an ECDSA P-256 public key.
-    ///
-    /// Not safe to call from arbitrary code as this does not return the reader index on failure: it relies on the caller performing
-    /// the rewind.
-    private mutating func readECDSAP256PublicKey() throws -> NIOSSHPublicKey? {
-        // For ECDSA-P256, the key format is the string "nistp256" followed by the
-        // the public point Q.
-        guard var domainParameter = self.readSSHString() else {
-            return nil
-        }
-        guard domainParameter.readableBytesView.elementsEqual("nistp256".utf8) else {
-            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
-            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
-        }
-
-        guard let qBytes = self.readSSHString() else {
-            return nil
-        }
-
-        let key = try P256.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
-        return NIOSSHPublicKey(backingKey: .ecdsaP256(key))
-    }
-
-    /// A helper function that reads an ECDSA P-384 public key.
-    ///
-    /// Not safe to call from arbitrary code as this does not return the reader index on failure: it relies on the caller performing
-    /// the rewind.
-    private mutating func readECDSAP384PublicKey() throws -> NIOSSHPublicKey? {
-        // For ECDSA-P384, the key format is the string "nistp384" followed by the
-        // the public point Q.
-        guard var domainParameter = self.readSSHString() else {
-            return nil
-        }
-        guard domainParameter.readableBytesView.elementsEqual("nistp384".utf8) else {
-            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
-            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
-        }
-
-        guard let qBytes = self.readSSHString() else {
-            return nil
-        }
-
-        let key = try P384.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
-        return NIOSSHPublicKey(backingKey: .ecdsaP384(key))
-    }
-
-    /// A helper function that reads an ECDSA P-521 public key.
-    ///
-    /// Not safe to call from arbitrary code as this does not return the reader index on failure: it relies on the caller performing
-    /// the rewind.
-    private mutating func readECDSAP521PublicKey() throws -> NIOSSHPublicKey? {
-        // For ECDSA-P521, the key format is the string "nistp521" followed by the
-        // the public point Q.
-        guard var domainParameter = self.readSSHString() else {
-            return nil
-        }
-        guard domainParameter.readableBytesView.elementsEqual("nistp521".utf8) else {
-            let unexpectedParameter = domainParameter.readString(length: domainParameter.readableBytes) ?? "<unknown domain parameter>"
-            throw NIOSSHError.invalidDomainParametersForKey(parameters: unexpectedParameter)
-        }
-
-        guard let qBytes = self.readSSHString() else {
-            return nil
-        }
-
-        let key = try P521.Signing.PublicKey(x963Representation: qBytes.readableBytesView)
-        return NIOSSHPublicKey(backingKey: .ecdsaP521(key))
     }
 
     /// A helper function for complex readers that will reset a buffer on nil or on error, as though the read

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKeyProtocol.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKeyProtocol.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+
+public protocol NIOSSHPublicKeyProtocol: Sendable {
+    /// An identifier that represents the type of public key used in an SSH packet.
+    /// This identifier MUST be unique to the public key implementation.
+    /// The returned value MUST NOT overlap with other public key implementations or a specifications that the public key does not implement.
+    static var publicKeyPrefix: String? { get }
+    var publicKeyPrefix: String { get }
+
+    /// The raw reprentation of this publc key as a blob.
+    var rawRepresentation: Data { get }
+
+    /// Verifies that `signature` is the result of signing `data` using the private key that this public key is derived from.
+    func isValidSignature<D: DataProtocol>(_ signature: NIOSSHSignature, for data: D) -> Bool
+
+    /// Serializes and writes the public key to the buffer. The calling function SHOULD NOT keep track of the size of the written blob.
+    /// If the result is not a fixed size, the serialized format SHOULD include a length.
+    func write(to buffer: inout ByteBuffer) -> Int
+    
+    func writeHostKey(to buffer: inout ByteBuffer) -> Int
+
+    /// Reads this Public Key from the buffer using the same format implemented in `write(to:)`
+    static func read(from buffer: inout ByteBuffer) throws -> Self?
+}

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHSignatureProtocol.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHSignatureProtocol.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import NIOCore
+
+/// A signature is a mathematical scheme for verifying the authenticity of digital messages or documents.
+///
+/// This protocol can be implemented by a type that represents such a signature to NIOSSH.
+///
+/// - See: https://en.wikipedia.org/wiki/Digital_signature
+public protocol NIOSSHSignatureProtocol: Sendable {
+    /// An identifier that represents the type of signature used in an SSH packet.
+    /// This identifier MUST be unique to the signature implementation.
+    /// The returned value MUST NOT overlap with other signature implementations or a specifications that the signature does not implement.
+    static var signaturePrefix: String { get }
+
+    /// The raw reprentation of this signature as a blob.
+    var rawRepresentation: Data { get }
+
+    /// Serializes and writes the signature to the buffer. The calling function SHOULD NOT keep track of the size of the written blob.
+    /// If the result is not a fixed size, the serialized format SHOULD include a length.
+    func write(to buffer: inout ByteBuffer) -> Int
+
+    /// Reads this Signature from the buffer using the same format implemented in `write(to:)`
+    static func read(from buffer: inout ByteBuffer) throws -> Self
+}
+
+internal extension NIOSSHSignatureProtocol {
+    var signaturePrefix: String {
+        Self.signaturePrefix
+    }
+}

--- a/Sources/NIOSSH/NIOSSHError.swift
+++ b/Sources/NIOSSH/NIOSSHError.swift
@@ -47,6 +47,8 @@ extension NIOSSHError {
 
     internal static let invalidEncryptedPacketLength = NIOSSHError(type: .invalidEncryptedPacketLength, diagnostics: nil)
 
+    internal static let invalidSSHSignature = NIOSSHError(type: .invalidSSHSignature, diagnostics: nil)
+
     internal static let invalidDecryptedPlaintextLength = NIOSSHError(type: .invalidDecryptedPlaintextLength, diagnostics: nil)
 
     internal static let invalidKeySize = NIOSSHError(type: .invalidKeySize, diagnostics: nil)
@@ -180,6 +182,7 @@ extension NIOSSHError {
             case invalidHostKeyForKeyExchange
             case invalidOpenSSHPublicKey
             case invalidCertificate
+            case invalidSSHSignature
         }
 
         private var base: Base
@@ -277,6 +280,8 @@ extension NIOSSHError {
 
         /// A certificate failed validation.
         public static let invalidCertificate: ErrorType = .init(.invalidCertificate)
+
+        public static let invalidSSHSignature: ErrorType = .init(.invalidSSHSignature)
     }
 }
 

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
@@ -210,7 +210,7 @@ extension NIOSSHUserAuthenticationOffer.Offer {
 
         public init(privateKey: NIOSSHPrivateKey, certifiedKey: NIOSSHCertifiedPublicKey) {
             self.privateKey = privateKey
-            self.publicKey = NIOSSHPublicKey(certifiedKey)
+            self.publicKey = NIOSSHPublicKey(backingKey: certifiedKey)
         }
     }
 

--- a/Tests/NIOSSHTests/CertifiedKeyTests.swift
+++ b/Tests/NIOSSHTests/CertifiedKeyTests.swift
@@ -79,7 +79,7 @@ final class CertifiedKeyTests: XCTestCase {
             XCTFail("Key is not certified")
             return
         }
-        let secondKey = NIOSSHPublicKey(certifiedKey)
+        let secondKey = NIOSSHPublicKey(backingKey: certifiedKey)
         XCTAssertEqual(key, secondKey)
         let setOfKeys = Set([key, secondKey])
         XCTAssertEqual(setOfKeys.count, 1)
@@ -469,7 +469,7 @@ final class CertifiedKeyTests: XCTestCase {
         XCTAssertThrowsError(try NIOSSHCertifiedPublicKey(nonce: userKey.nonce,
                                                           serial: userKey.serial,
                                                           type: userKey.type,
-                                                          key: NIOSSHPublicKey(hostKey),
+                                                          key: NIOSSHPublicKey(backingKey: hostKey),
                                                           keyID: userKey.keyID,
                                                           validPrincipals: userKey.validPrincipals,
                                                           validAfter: userKey.validAfter,
@@ -496,7 +496,7 @@ final class CertifiedKeyTests: XCTestCase {
                                                           validBefore: userKey.validBefore,
                                                           criticalOptions: userKey.criticalOptions,
                                                           extensions: userKey.extensions,
-                                                          signatureKey: NIOSSHPublicKey(hostKey),
+                                                          signatureKey: NIOSSHPublicKey(backingKey: hostKey),
                                                           signature: userKey.signature)) { error in
             XCTAssertEqual((error as? NIOSSHError)?.type, .invalidCertificate)
         }

--- a/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHKeyExchangeStateMachineTests.swift
@@ -378,7 +378,7 @@ final class SSHKeyExchangeStateMachineTests: XCTestCase {
 
     func testExtraECDHReplyForbidden() throws {
         let privateKey = Curve25519.Signing.PrivateKey()
-        let message = SSHMessage.keyExchangeReply(.init(hostKey: .init(backingKey: .ed25519(privateKey.publicKey)), publicKey: ByteBufferAllocator().buffer(capacity: 1024), signature: .init(backingSignature: .ed25519(.byteBuffer(ByteBufferAllocator().buffer(capacity: 1024))))))
+        let message = SSHMessage.keyExchangeReply(.init(hostKey: .init(backingKey: privateKey.publicKey), publicKey: ByteBufferAllocator().buffer(capacity: 1024), signature: .init(backingSignature: Curve25519Signature(rawRepresentation: Data(repeating: 0x00, count: 1024)))))
         try self.assertSendingExtraMessageFails(message: message, allowedStages: .beforeReceiveKeyExchangeReplyClient)
     }
 

--- a/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
+++ b/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
@@ -187,9 +187,9 @@ final class SSHPacketSerializerTests: XCTestCase {
         let key = try Curve25519.Signing.PublicKey(rawRepresentation: [182, 37, 100, 183, 198, 201, 188, 148, 70, 200, 201, 225, 14, 66, 236, 124, 45, 246, 72, 46, 242, 24, 149, 170, 135, 58, 10, 18, 208, 163, 106, 118])
         let signature = Data([18, 95, 167, 169, 241, 132, 161, 143, 58, 35, 228, 10, 66, 187, 185, 176, 60, 95, 53, 188, 238, 226, 202, 75, 45, 226, 101, 39, 51, 168, 2, 92, 211, 28, 235, 229, 200, 249, 234, 71, 231, 245, 198, 167, 222, 207, 11, 151, 144, 218, 148, 205, 15, 77, 69, 72, 201, 37, 125, 94, 227, 173, 194, 10])
         let message = SSHMessage.keyExchangeReply(.init(
-            hostKey: NIOSSHPublicKey(backingKey: .ed25519(key)),
+            hostKey: NIOSSHPublicKey(backingKey: key),
             publicKey: ByteBuffer.of(bytes: [42, 42]),
-            signature: NIOSSHSignature(backingSignature: .ed25519(.data(signature)))
+            signature: NIOSSHSignature(backingSignature: Curve25519Signature(rawRepresentation: signature))
         ))
         let allocator = ByteBufferAllocator()
         var serializer = SSHPacketSerializer()
@@ -205,15 +205,15 @@ final class SSHPacketSerializerTests: XCTestCase {
         switch try parser.nextPacket() {
         case .keyExchangeReply(let message):
             switch message.hostKey.backingKey {
-            case .ed25519(let bytes):
-                XCTAssertEqual(key.rawRepresentation, bytes.rawRepresentation)
+            case let parsedKey as Curve25519.Signing.PublicKey:
+                XCTAssertEqual(key.rawRepresentation, parsedKey.rawRepresentation)
             default:
                 XCTFail("Key is incorrect")
             }
             XCTAssertEqual(ByteBuffer.of(bytes: [42, 42]), message.publicKey)
             switch message.signature.backingSignature {
-            case .ed25519(.byteBuffer(let bytes)):
-                XCTAssertEqual(signature, Data(bytes.readableBytesView))
+            case let parsedSignature as Curve25519Signature:
+                XCTAssertEqual(signature, Data(parsedSignature.rawRepresentation))
             default:
                 XCTFail("Signature is incorrect")
             }

--- a/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
@@ -780,10 +780,10 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         XCTAssertNoThrow(try self.beginAuthentication(stateMachine: &stateMachine))
         stateMachine.sendServiceRequest(.init(service: "ssh-userauth"))
 
-        let dataToSign = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: NIOSSHPublicKey(delegate.certifiedKey))
+        let dataToSign = UserAuthSignablePayload(sessionIdentifier: self.sessionID, userName: "foo", serviceName: "ssh-connection", publicKey: NIOSSHPublicKey(backingKey: delegate.certifiedKey))
         let signature = try delegate.privateKey.sign(dataToSign)
 
-        let firstMessage = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: NIOSSHPublicKey(delegate.certifiedKey), signature: signature)))
+        let firstMessage = SSHMessage.UserAuthRequestMessage(username: "foo", service: "ssh-connection", method: .publicKey(.known(key: NIOSSHPublicKey(backingKey: delegate.certifiedKey), signature: signature)))
         XCTAssertNoThrow(try self.serviceAccepted(service: "ssh-userauth", nextMessage: firstMessage, userAuthPayload: dataToSign, stateMachine: &stateMachine))
         stateMachine.sendUserAuthRequest(firstMessage)
 


### PR DESCRIPTION
As it stands, all the supported public/private key implementations are deeply integrated with NIOSSH through the internal enums that NIOSSH relies on. This PR moves that responsibility into a protocol conformance, paving the way towards custom public/private key types - and therefore moving towards supporting older/insecure standards such as RSA.