### PR TITLE
Workaround allocation regression caused by missing specialized `[Substring].joined`

### DIFF
--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -1289,7 +1289,7 @@ extension ByteBuffer {
         ///
         /// - See: https://github.com/apple/swift/issues/69883
         var joinedAlgorithms: [UInt8] = []
-        joinedAlgorithms.reserveCapacity(algorithms.reduce(0, { $0 + $1.count + 1 }))
+        joinedAlgorithms.reserveCapacity(algorithms.reduce(0) { $0 + $1.count + 1 })
         var iterator = algorithms.makeIterator()
         if let algorithm = iterator.next() {
             joinedAlgorithms.append(contentsOf: algorithm.utf8)

--- a/Sources/NIOSSH/SSHMessages.swift
+++ b/Sources/NIOSSH/SSHMessages.swift
@@ -1285,7 +1285,20 @@ extension ByteBuffer {
     }
 
     mutating func writeAlgorithms(_ algorithms: [Substring]) -> Int {
-        self.writeSSHString(algorithms.joined(separator: ",").utf8)
+        /// Work around the lack of sepicalized `[Substring].join` since Swift 5.9:
+        ///
+        /// - See: https://github.com/apple/swift/issues/69883
+        var joinedAlgorithms: [UInt8] = []
+        joinedAlgorithms.reserveCapacity(algorithms.reduce(0, { $0 + $1.count + 1 }))
+        var iterator = algorithms.makeIterator()
+        if let algorithm = iterator.next() {
+            joinedAlgorithms.append(contentsOf: algorithm.utf8)
+            while let algorithm = iterator.next() {
+                joinedAlgorithms.append(UInt8(ascii: ","))
+                joinedAlgorithms.append(contentsOf: algorithm.utf8)
+            }
+        }
+        return self.writeSSHString(joinedAlgorithms)
     }
 
     mutating func writeUserAuthRequestMessage(_ message: SSHMessage.UserAuthRequestMessage) -> Int {

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -14,9 +14,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.10
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=199900
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1060050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=43050
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -16,7 +16,7 @@ services:
     image: swift-nio-ssh:22.04-5.7
     environment:
       - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=199800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=970050
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=952050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=42950
       #- SANITIZER_ARG=--sanitize=thread
       #- WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -15,8 +15,8 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=957050
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
       - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -15,9 +15,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.9
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=199900
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1060050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=43050
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=199800
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=949050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=42950
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -14,9 +14,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193900
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=1050050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=41050
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors


### PR DESCRIPTION
### Motivation

The specialization for `[Substring].joined` was dropped in Swift 5.9[^1] and consequently we regressed in allocations[^2].

### Modifications

Workaround the lack of specialized `[Substring].joined` by handwriting the comma-separated concatenation of the SSH algorithms.

### Result

Reduces the allocations to below what they were prior to the toolchain regression.

### Notes

As a baseline, I was using `d23c142` of this repo, which is a commit from around the time of the toolchain regression.

The allocation results are as follows:

| swift-nio-ssh     | swift toolchain  | allocs    |
|------------------:|:-----------------|----------:|
| d23c142 (Aug 11)  | 5.9-2023-07-25   | 1,007,000 |
|                   | 5.9-2023-07-29   | 1,100,000 |
|                   | 5.9-RELEASE       | 1,100,000 |
| d23c142 + patch   | 5.9-2023-07-25   |  989,000  |
|                   | 5.9-2023-07-29   |  989,000  |
|                   | 5.9-RELEASE       |  989,000  |
| d33c701 (main)    | 5.9-RELEASE       | 1,060,000 |
| main + patch      | 5.9-RELEASE       |  949,000  |

From this we infer:
1. The allocation regression was caused by a regression in Swift 5.9 between nightly versions `2023-07-25` and `2023-07-29`.
2. The same regression is still present in `5.9-RELEASE`.
3. The patch seems to mitigate the regression we're seeing as a result of the new 5.9 behavior.
4. Since the original regression we actually saved some 40k allocations by some other change in the code (either here, or more likely in a dependency).

For more information on the Swift issue, including reproducer package and `heaptrack` outputs, see the Swift issue[^1].

[^1]: https://github.com/apple/swift/issues/69883
[^2]: #157 
