### PR TITLE
Android: force unwrap address passed to fwrite() for NDK 26

### DIFF
--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -100,7 +100,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
         case .stdErr:
             // We just write to stderr directly, pipe channel can't help us here.
             bytes.withUnsafeReadableBytes { str in
-                let rc = fwrite(str.baseAddress, 1, str.count, stderr)
+                let rc = fwrite(str.baseAddress!, 1, str.count, stderr)
                 precondition(rc == str.count)
             }
 


### PR DESCRIPTION
Motivation:

Get this repo building with Android NDK 26, [which added nullability annotations](https://android.googlesource.com/platform/bionic/+/00a3dbaab65a7d628312fd67099c662942b1d45f%5E%21/#F0)

Modifications:

- A single force unwrap of a buffer's `baseAddress`

Result:

This repo builds and passes its tests with the latest Android LTS NDK 26.

I made sure this pull doesn't break anything by testing it on linux x86_64 and with the previous NDK 25c too. I used this patch with others to build the Swift toolchain and this package for my Android CI, finagolfin/swift-android-sdk#122.