### PR TITLE
Fix build on non-macOS Apple platforms

### DIFF
--- a/Sources/NIOSSHServer/DataToBufferCodec.swift
+++ b/Sources/NIOSSHServer/DataToBufferCodec.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation.Process)
+
 import Dispatch
 import Foundation
 import NIOCore
@@ -57,3 +59,5 @@ func createOutboundConnection(targetHost: String, targetPort: Int, loop: EventLo
         channel.eventLoop.makeSucceededFuture(())
     }.connect(host: targetHost, port: targetPort)
 }
+
+#endif // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/ExecHandler.swift
+++ b/Sources/NIOSSHServer/ExecHandler.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation.Process)
+
 import Dispatch
 import Foundation
 import NIOCore
@@ -156,3 +158,5 @@ final class ExampleExecHandler: ChannelDuplexHandler {
         }
     }
 }
+
+#endif // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/GlueHandler.swift
+++ b/Sources/NIOSSHServer/GlueHandler.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation.Process)
+
 import NIOCore
 
 final class GlueHandler {
@@ -122,3 +124,5 @@ extension GlueHandler: ChannelDuplexHandler {
         }
     }
 }
+
+#endif // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/RemotePortForwarding.swift
+++ b/Sources/NIOSSHServer/RemotePortForwarding.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation.Process)
+
 import Dispatch
 import Foundation
 import NIOCore
@@ -97,3 +99,5 @@ final class RemotePortForwarderGlobalRequestDelegate: GlobalRequestDelegate {
         self.forwarder?.stopListening()
     }
 }
+
+#endif // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/main.swift
+++ b/Sources/NIOSSHServer/main.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Foundation.Process)
+
 import Crypto
 import Dispatch
 import NIOCore
@@ -85,3 +87,9 @@ let channel = try bootstrap.bind(host: "0.0.0.0", port: 2222).wait()
 
 // Run forever
 try channel.closeFuture.wait()
+
+#else // canImport(Foundation.Process)
+
+fatalError("NIOSSHServer is only supported on platforms with Foundation.Process")
+
+#endif // !canImport(Foundation.Process)

--- a/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
+++ b/Tests/NIOSSHTests/SSHConnectionStateMachineTests.swift
@@ -591,6 +591,7 @@ final class SSHConnectionStateMachineTests: XCTestCase {
         }
     }
 
+    @available(iOS 13.2, macOS 10.15, watchOS 6.1, tvOS 13.2, *)
     func testFirstBlockDecodedOnce() throws {
         let allocator = ByteBufferAllocator()
         let loop = EmbeddedEventLoop()

--- a/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
+++ b/Tests/NIOSSHTests/SSHPackerSerializerTests.swift
@@ -243,6 +243,7 @@ final class SSHPacketSerializerTests: XCTestCase {
         }
     }
 
+    @available(iOS 13.2, macOS 10.15, watchOS 6.1, tvOS 13.2, *)
     func testSequencePreservedBetweenPlainAndCypher() {
         let message = SSHMessage.newKeys
         let allocator = ByteBufferAllocator()

--- a/Tests/NIOSSHTests/SSHPacketParserTests.swift
+++ b/Tests/NIOSSHTests/SSHPacketParserTests.swift
@@ -249,6 +249,7 @@ final class SSHPacketParserTests: XCTestCase {
         XCTAssertEqual(parser._discardableBytes, 0)
     }
 
+    @available(iOS 13.2, macOS 10.15, watchOS 6.1, tvOS 13.2, *)
     func testSequencePreservedBetweenPlainAndCypher() throws {
         let allocator = ByteBufferAllocator()
         var parser = SSHPacketParser(isServer: false, allocator: allocator)

--- a/Tests/NIOSSHTests/Utilities.swift
+++ b/Tests/NIOSSHTests/Utilities.swift
@@ -98,6 +98,7 @@ struct InsecureEncryptionAlgorithm {
     }
 }
 
+@available(iOS 13.2, macOS 10.15, watchOS 6.1, tvOS 13.2, *)
 class TestTransportProtection: NIOSSHTransportProtection {
     enum TestError: Error {
         case doubleDecode

--- a/Tests/NIOSSHTests/UtilitiesTests.swift
+++ b/Tests/NIOSSHTests/UtilitiesTests.swift
@@ -28,6 +28,7 @@ final class UtilitiesTests: XCTestCase {
         XCTAssertEqual(message, plaintext)
     }
 
+    @available(iOS 13.2, macOS 10.15, watchOS 6.1, tvOS 13.2, *)
     func testTestTransportProtection() throws {
         let inboundEncryptionKey = SymmetricKey(size: .bits128)
         let outboundEncryptionKey = SymmetricKey(size: .bits128)


### PR DESCRIPTION
## Motivation

When building this project for Apple platforms other than macOS, the build failed for a couple of reasons. First, `NIOSSHServer` requires `Foundation.Process` which is only available on macOS. Second, the tests are making use of an CryptoKit API that's only present on iOS 13.2 (and aligned other versions), which is newer than the 13.0 stated in the Package.swift:

```
error: Cannot find type 'Process' in scope
...
error: 'isValidAuthenticationCode(_:authenticating:using:)' is only available in iOS 13.2 or newer
```

## Modifications

- Wrap all the code in `NIOSSHServer` with `#if canImport(Foundation.Process)` and, in `main.swift`, throw a `fatalError` with a helpful message.
- Add missing availability guards in test code. I've tried to keep them as scoped as possible.

## Result

Source and tests can now build on Apple platforms other than macOS.
