### PR TITLE
Add Musl support for static cross compilation.

### DIFF
--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -21,6 +21,8 @@ import Darwin
 import Glibc
 #elseif canImport(Bionic)
 import Bionic
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /// A ``NIOSSHCertifiedPublicKey`` is an SSH public key combined with an SSH certificate.


### PR DESCRIPTION
Motivation:

Provide a fix for Issue #170 as well as being able to use NIO SSH in projects that want to cross-compile to Linux.

Modifications:

Add import for Musl if available.

Result:

Cross-compiling to both x86_64 and aarch64 works.