### PR TITLE
Lower alloc limits to lock-in upstream wins

### DIFF
--- a/dev/update-alloc-limits-to-last-completed-ci-build
+++ b/dev/update-alloc-limits-to-last-completed-ci-build
@@ -22,7 +22,7 @@ url_prefix=${1-"https://ci.swiftserver.group/job/swift-nio-ssh-"}
 target_repo=${2-"$here/.."}
 tmpdir=$(mktemp -d /tmp/.last-build_XXXXXX)
 
-for f in 56 57 58 59 nightly; do
+for f in 58 59 510 nightly; do
     echo "swift$f"
     if [[ "$f" == "nightly" ]]; then
         url="$url_prefix$f-prb/lastCompletedBuild/consoleFull"

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -15,9 +15,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.10
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=192700
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=852050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40850
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -15,9 +15,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.8
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=192700
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=852050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40850
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -15,9 +15,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-5.9
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=199800
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=949050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=42950
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=198700
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=862050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=42850
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -14,9 +14,9 @@ services:
   test:
     image: swift-nio-ssh:22.04-main
     environment:
-      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=193750
-      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=939050
-      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40950
+      - MAX_ALLOCS_ALLOWED_client_server_many_small_commands_per_connection=192700
+      - MAX_ALLOCS_ALLOWED_client_server_one_command_per_connection=852050
+      - MAX_ALLOCS_ALLOWED_client_server_streaming_large_message_in_small_chunks=40850
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       #- SANITIZER_ARG=--sanitize=thread
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors


### PR DESCRIPTION
### Motivation:

Changes in swift-nio and swift-atomics have resulted in fewer allocations in the benchmarks in swift-nio-ssh, so much improved that it caused tests to fail.

### Modifications:

Update the limits to take account of the gains, update the script to scrape the new limits to use 5.8, 5.9, 5.10.

### Result:

Allocation benchmark CI should pass again.