### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,3 +81,14 @@ let package = Package(
         ),
     ]
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 protocol AcceptsUserAuthMessages {
     var userAuthStateMachine: UserAuthenticationStateMachine { get set }
 

--- a/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
+++ b/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
@@ -16,6 +16,12 @@ import Crypto
 import NIOCore
 import NIOFoundationCompat
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 /// This protocol defines a container used by the key exchange state machine to manage key exchange.
 /// This type erases the specific key exchanger.
 protocol EllipticCurveKeyExchangeProtocol {

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -12,9 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CDispatch
 import Crypto
 import Dispatch
 import NIOCore
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPrivateKey.swift
@@ -15,6 +15,12 @@
 @preconcurrency import Crypto
 import NIOCore
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 /// An SSH private key.
 ///
 /// This object identifies a single SSH entity, usually a server. It is used as part of the SSH handshake and key exchange process,

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHPublicKey.swift
@@ -15,6 +15,7 @@
 @preconcurrency import Crypto
 import Foundation
 import NIOCore
+import NIOFoundationCompat
 
 /// An SSH public key.
 ///

--- a/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
+++ b/Sources/NIOSSHPerformanceTester/BenchmarkHandshake.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import NIOCore
+import NIOEmbedded
 import NIOSSH
 
 final class BenchmarkHandshake: Benchmark {

--- a/Sources/NIOSSHPerformanceTester/BenchmarkLinearThroughput.swift
+++ b/Sources/NIOSSHPerformanceTester/BenchmarkLinearThroughput.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import NIOCore
+import NIOEmbedded
 import NIOSSH
 
 final class BenchmarkLinearThroughput: Benchmark {

--- a/Tests/NIOSSHTests/HostKeyTests.swift
+++ b/Tests/NIOSSHTests/HostKeyTests.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import NIOCore
+import NIOFoundationCompat
 import XCTest
 
 @testable import NIOSSH


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.