### PR TITLE
Fix build on all platforms

### DIFF
--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(CDispatch)
-import CDispatch
-#endif
-
 import Crypto
 import Dispatch
 import NIOCore
+
+#if canImport(CDispatch)
+import CDispatch
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -398,20 +398,11 @@ extension NIOSSHCertifiedPublicKey: CustomDebugStringConvertible {
     public var debugDescription: String {
         // Slightly hacky multiline string to try to keep things
         // clear.
-        "NIOSSHCertifiedPublicKey(" +
-            "nonce: \(self.nonce), " +
-            "serial: \(self.serial), " +
-            "type: \(self.type), " +
-            "key: \(self.key), " +
-            "keyID: \(self.keyID), " +
-            "validPrincipals: \(self.validPrincipals), " +
-            "validAfter: \(self.validAfter), " +
-            "validBefore: \(self.validBefore), " +
-            "criticalOptions: \(self.criticalOptions), " +
-            "extensions: \(self.extensions), " +
-            "signatureKey: \(self.signatureKey), " +
-            "signature: \(self.signature)" +
-        ")"
+        "NIOSSHCertifiedPublicKey(nonce: \(self.nonce), serial: \(self.serial), type: \(self.type), "
+            + "key: \(self.key), keyID: \(self.keyID), validPrincipals: \(self.validPrincipals), "
+            + "validAfter: \(self.validAfter), validBefore: \(self.validBefore), "
+            + "criticalOptions: \(self.criticalOptions), extensions: \(self.extensions), "
+            + "signatureKey: \(self.signatureKey), signature: \(self.signature))"
     }
 }
 

--- a/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
+++ b/Sources/NIOSSH/Keys And Signatures/NIOSSHCertifiedPublicKey.swift
@@ -12,7 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(CDispatch)
 import CDispatch
+#endif
+
 import Crypto
 import Dispatch
 import NIOCore
@@ -393,22 +396,22 @@ extension NIOSSHCertifiedPublicKey: Hashable {}
 
 extension NIOSSHCertifiedPublicKey: CustomDebugStringConvertible {
     public var debugDescription: String {
-        """
-        NIOSSHCertifiedPublicKey(
-            nonce: \(self.nonce),
-            serial: \(self.serial),
-            type: \(self.type),
-            key: \(self.key),
-            keyID: \(self.keyID),
-            validPrincipals: \(self.validPrincipals),
-            validAfter: \(self.validAfter),
-            validBefore: \(self.validBefore),
-            criticalOptions: \(self.criticalOptions),
-            extensions: \(self.extensions),
-            signatureKey: \(self.signatureKey),
-            signature: \(self.signature)
-        )
-        """.replacingOccurrences(of: "\n", with: "")
+        // Slightly hacky multiline string to try to keep things
+        // clear.
+        "NIOSSHCertifiedPublicKey(" +
+            "nonce: \(self.nonce), " +
+            "serial: \(self.serial), " +
+            "type: \(self.type), " +
+            "key: \(self.key), " +
+            "keyID: \(self.keyID), " +
+            "validPrincipals: \(self.validPrincipals), " +
+            "validAfter: \(self.validAfter), " +
+            "validBefore: \(self.validBefore), " +
+            "criticalOptions: \(self.criticalOptions), " +
+            "extensions: \(self.extensions), " +
+            "signatureKey: \(self.signatureKey), " +
+            "signature: \(self.signature)" +
+        ")"
     }
 }
 


### PR DESCRIPTION
Motivation:

It turns out that #183 broke the build on a number of platforms, including Linux 6.1+, Android 6.1+, and on 6.0 macOS. We need to keep things building.

Modifications:

Guard the import of CDispatch
Remove the use of replacingOccurrences

Result:

Better builds.