### PR TITLE
Get handler from correct channel in tests

### DIFF
--- a/Tests/NIOSSHTests/EndToEndTests.swift
+++ b/Tests/NIOSSHTests/EndToEndTests.swift
@@ -35,7 +35,7 @@ class BackToBackEmbeddedChannel {
     }
 
     var serverSSHHandler: NIOSSHHandler? {
-        try? self.client.pipeline.handler(type: NIOSSHHandler.self).wait()
+        try? self.server.pipeline.handler(type: NIOSSHHandler.self).wait()
     }
 
     init() {


### PR DESCRIPTION
Motivation:

Some tests rely on extracting the server handler from a channel pipeline. There's a typo here where the handler is pulled from the client channel, meaning its client handler not the server handler.

Modifications:

- Get the server handler from the server channel

Result:

Tests still pass