### PR TITLE
Strict concurrency for NIOSSH

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,24 @@
 
 import PackageDescription
 
+let strictConcurrencyDevelopment = false
+
+let strictConcurrencySettings: [SwiftSetting] = {
+    var initialSettings: [SwiftSetting] = []
+    initialSettings.append(contentsOf: [
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+
+    if strictConcurrencyDevelopment {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
+        initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
+    }
+
+    return initialSettings
+}()
+
 let package = Package(
     name: "swift-nio-ssh",
     platforms: [
@@ -27,7 +45,7 @@ let package = Package(
         .library(name: "NIOSSH", targets: ["NIOSSH"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
@@ -40,7 +58,8 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "Atomics", package: "swift-atomics"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .executableTarget(
             name: "NIOSSHClient",

--- a/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelOptions.swift
@@ -33,7 +33,7 @@ public struct SSHChildChannelOptions: Sendable {
 
 extension SSHChildChannelOptions {
     /// Types for the ``SSHChildChannelOptions``.
-    public enum Types {}
+    public enum Types: Sendable {}
 }
 
 extension SSHChildChannelOptions.Types {

--- a/Sources/NIOSSH/Child Channels/ChildChannelUserEvents.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelUserEvents.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// A namespace for SSH channel request events.
-public enum SSHChannelRequestEvent {
+public enum SSHChannelRequestEvent: Sendable {
     /// A request for the peer to allocate a pseudo-terminal.
     public struct PseudoTerminalRequest: Hashable, Sendable {
         /// Whether a reply to this PTY request is desired.
@@ -315,17 +315,16 @@ extension SSHChannelRequestEvent {
     /// Constructs a channel request event and wraps it up in an Any.
     ///
     /// This is usually used just prior to firing this into the pipeline.
-    internal static func fromMessage(_ message: SSHMessage.ChannelRequestMessage) -> Any? {
+    internal static func fromMessage(_ message: SSHMessage.ChannelRequestMessage) -> (any Sendable)? {
         switch message.type {
         case .env(let name, let value):
-            return EnvironmentRequest(wantReply: message.wantReply, name: name, value: value) as Any
+            return EnvironmentRequest(wantReply: message.wantReply, name: name, value: value)
         case .exec(let command):
-            return ExecRequest(command: command, wantReply: message.wantReply) as Any
+            return ExecRequest(command: command, wantReply: message.wantReply)
         case .exitStatus(let code):
-            return ExitStatus(exitStatus: code) as Any
+            return ExitStatus(exitStatus: code)
         case .exitSignal(let name, let dumpedCore, let errorMessage, let language):
             return ExitSignal(signalName: name, errorMessage: errorMessage, language: language, dumpedCore: dumpedCore)
-                as Any
         case .ptyReq(let ptyReq):
             return PseudoTerminalRequest(
                 wantReply: message.wantReply,
@@ -337,9 +336,9 @@ extension SSHChannelRequestEvent {
                 terminalModes: ptyReq.terminalModes
             )
         case .shell:
-            return ShellRequest(wantReply: message.wantReply) as Any
+            return ShellRequest(wantReply: message.wantReply)
         case .subsystem(let subsystem):
-            return SubsystemRequest(subsystem: subsystem, wantReply: message.wantReply) as Any
+            return SubsystemRequest(subsystem: subsystem, wantReply: message.wantReply)
         case .windowChange(let windowChange):
             return WindowChangeRequest(
                 terminalCharacterWidth: windowChange.characterWidth,
@@ -348,7 +347,7 @@ extension SSHChannelRequestEvent {
                 terminalPixelHeight: windowChange.pixelHeight
             )
         case .xonXoff(let clientCanDo):
-            return LocalFlowControlRequest(clientCanDo: clientCanDo) as Any
+            return LocalFlowControlRequest(clientCanDo: clientCanDo)
         case .signal(let signalName):
             return SignalRequest(signal: signalName)
         case .unknown:

--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -680,7 +680,7 @@ extension SSHChildChannel {
                 )
                 self.processOutboundMessage(.channelWindowAdjust(update), promise: nil)
             }
-            self.pipeline.fireChannelRead(NIOAny(data))
+            self.pipeline.syncOperations.fireChannelRead(NIOAny(data))
 
         case .eof:
             self.pipeline.fireUserInboundEventTriggered(ChannelEvent.inputClosed)

--- a/Sources/NIOSSH/GlobalRequestDelegate.swift
+++ b/Sources/NIOSSH/GlobalRequestDelegate.swift
@@ -44,7 +44,7 @@ extension GlobalRequestDelegate {
 }
 
 /// A namespace of ``GlobalRequest`` objects that implementations of ``GlobalRequestDelegate`` may be asked to handle.
-public enum GlobalRequest {
+public enum GlobalRequest: Sendable {
     /// A request from a client to a server for the server to listen on a port on the client's behalf. If accepted,
     /// the server will listen on a port, and will forward accepted connections to the client using the "forwarded-tcpip"
     /// channel type.

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -228,7 +228,7 @@ extension NIOSSHHandler: ChannelDuplexHandler {
             break
         case .possibleFutureMessage(let future):
             // TODO(cory): This is not right, but for now it's good enough.
-            future.whenComplete { result in
+            future.hop(to: context.eventLoop).assumeIsolatedUnsafeUnchecked().whenComplete { result in
                 switch result {
                 case .success(.some(let message)):
                     do {
@@ -413,7 +413,8 @@ extension NIOSSHHandler {
             }
         }
 
-        responsePromise.futureResult.whenComplete { result in
+        // The promise is created a few lines above on the context's event loop, so this is safe.
+        responsePromise.futureResult.assumeIsolatedUnsafeUnchecked().whenComplete { result in
             guard message.wantReply else {
                 // Nothing to do.
                 return
@@ -472,7 +473,7 @@ extension NIOSSHHandler {
         // Sending a single global request is tricky, because we don't want to succeed the promise until we have the result of the
         // request. That means we need a buffer of promises for request success/failure messages, as well as to create new promises.
         let writePromise = context.eventLoop.makePromise(of: Void.self)
-        writePromise.futureResult.whenComplete { result in
+        writePromise.futureResult.assumeIsolatedUnsafeUnchecked().whenComplete { result in
             switch result {
             case .success:
                 guard self.context != nil else {

--- a/Sources/NIOSSH/Role.swift
+++ b/Sources/NIOSSH/Role.swift
@@ -47,3 +47,6 @@ public enum SSHConnectionRole {
         }
     }
 }
+
+@available(*, unavailable)
+extension SSHConnectionRole: Sendable {}

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -51,3 +51,7 @@ public struct SSHClientConfiguration {
         self.transportProtectionSchemes = transportProtectionSchemes
     }
 }
+
+// The various delegates aren't required to be Sendable, so the config isn't sendable.
+@available(*, unavailable)
+extension SSHClientConfiguration: Sendable {}

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -72,6 +72,10 @@ public struct SSHServerConfiguration {
     }
 }
 
+// The various delegates aren't required to be Sendable, so the config isn't sendable.
+@available(*, unavailable)
+extension SSHServerConfiguration: Sendable {}
+
 // MARK: - UserAuthBanner
 
 extension SSHServerConfiguration {

--- a/Sources/NIOSSH/User Authentication/ClientUserAuthenticationDelegate.swift
+++ b/Sources/NIOSSH/User Authentication/ClientUserAuthenticationDelegate.swift
@@ -26,7 +26,7 @@ import NIOCore
 public protocol NIOSSHClientUserAuthenticationDelegate {
     /// Called when ``NIOSSH`` would like to attempt to offer a new authentication method.
     ///
-    /// The callback is provided the authentictation methods that the server is willing to accept in
+    /// The callback is provided the authentication methods that the server is willing to accept in
     /// `availableMethods`. The delegate needs to provide an authentication offer by completing
     /// `nextChallengePromise`. If no further authentication offers are available (perhaps because the server
     /// has rejected them all) then this promise should be failed, which will terminate connection establishment.


### PR DESCRIPTION
Modifications:

- Add missing explicit annotations
- Use `any Sendable` rather than `Any` when dealing with user events internally
- Use the isolated event loop where necessary
- Fix a typo