### PR TITLE
Marks SSHChannelData as sendable

### DIFF
--- a/Sources/NIOSSH/Child Channels/SSHChannelData.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelData.swift
@@ -34,7 +34,6 @@ public struct SSHChannelData {
 
 extension SSHChannelData: Equatable {}
 
-@available(*, unavailable)
 extension SSHChannelData: Sendable {}
 
 extension SSHChannelData {


### PR DESCRIPTION
Motivation:
Since IOData now sendable we can mark SSHChannel data sendable as well. This is required if we want to wrap SSH channel in a NIOAsyncChannel that operates with SSHChannelData

Modifications:
 - Remove unavailable from sendable conformance

Result:
 - SSHChannelData is now sendable