### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,4 +27,5 @@ jobs:
         name: macOS tests
         uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
         with:
+            runner_pool: nightly
             build_scheme: swift-nio-ssh-Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,3 +29,10 @@ jobs:
     cxx-interop:
         name: Cxx interop
         uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+
+    macos-tests:
+        name: macOS tests
+        uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+        with:
+            runner_pool: general
+            build_scheme: swift-nio-ssh-Package


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
