### PR TITLE
Re-enable warnings-as-errors on Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         with:
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
         with:
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/Sources/NIOSSHClient/ExecHandler.swift
+++ b/Sources/NIOSSHClient/ExecHandler.swift
@@ -113,7 +113,7 @@ final class ExampleExecHandler: ChannelDuplexHandler {
         case .stdErr:
             // We just write to stderr directly, pipe channel can't help us here.
             bytes.withUnsafeReadableBytes { str in
-                let rc = fwrite(str.baseAddress!, 1, str.count, stderr)
+                let rc = writeToFD(STDERR_FILENO, str.baseAddress!, str.count)
                 precondition(rc == str.count)
             }
 
@@ -126,6 +126,11 @@ final class ExampleExecHandler: ChannelDuplexHandler {
         let data = self.unwrapOutboundIn(data)
         context.write(self.wrapOutboundOut(SSHChannelData(type: .channel, data: .byteBuffer(data))), promise: promise)
     }
+}
+
+@inlinable
+func writeToFD(_ fd: Int32, _ buf: UnsafeRawPointer!, _ nbyte: Int) -> Int {
+    write(fd, buf, nbyte)
 }
 
 enum SSHClientError: Swift.Error {


### PR DESCRIPTION
Re-enable warnings-as-errors on Swift 6.0 now that strict concurrency issues have been resolved.