### PR TITLE
Add "-Xfrontend" to strict concurrency settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let strictConcurrencySettings: [SwiftSetting] = {
     if strictConcurrencyDevelopment {
         // -warnings-as-errors here is a workaround so that IDE-based development can
         // get tripped up on -require-explicit-sendable.
-        initialSettings.append(.unsafeFlags(["-require-explicit-sendable", "-warnings-as-errors"]))
+        initialSettings.append(.unsafeFlags(["-Xfrontend", "-require-explicit-sendable", "-warnings-as-errors"]))
     }
 
     return initialSettings


### PR DESCRIPTION
Add "-Xfrontend" to strict concurrency settings `-require-explicit-sendable` flag, it doesn't seem to work consistently without it.