### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 
 import PackageDescription
 

--- a/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 198663
-}

--- a/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 859999
-}

--- a/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/5.9/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 42838
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SwiftNIO SSH        | Minimum Swift Version
 `0.6.2  ..< 0.9.0`  | 5.6
 `0.9.0  ..< 0.9.2`  | 5.8
 `0.9.2  ..< 0.10.0` | 5.9
-`0.10.0 ..<`        | 5.10
+`0.10.0 ...`        | 5.10
 
 ## What does SwiftNIO SSH support?
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ Another good reason to provide programmatic SSH is that it is not uncommon for s
 
 The most recent versions of SwiftNIO SSH support Swift 5.9 and newer. The minimum Swift version supported by SwiftNIO SSH releases are detailed below:
 
-SwiftNIO SSH      | Minimum Swift Version
-------------------|----------------------
-`0.0.0 ..< 0.3.0` | 5.1
-`0.3.0 ..< 0.4.0` | 5.2
-`0.4.0 ..< 0.5.0` | 5.4
-`0.5.0 ..< 0.6.2` | 5.5.2
-`0.6.2 ..< 0.9.0` | 5.6
-`0.9.0 ..< 0.9.2` | 5.8
-`0.9.2 ..<`       | 5.9  **TODO:** Update version table
+SwiftNIO SSH        | Minimum Swift Version
+--------------------|----------------------
+`0.0.0  ..< 0.3.0`  | 5.1
+`0.3.0  ..< 0.4.0`  | 5.2
+`0.4.0  ..< 0.5.0`  | 5.4
+`0.5.0  ..< 0.6.2`  | 5.5.2
+`0.6.2  ..< 0.9.0`  | 5.6
+`0.9.0  ..< 0.9.2`  | 5.8
+`0.9.2  ..< 0.10.0` | 5.9
+`0.10.0 ..<`        | 5.10
 
 ## What does SwiftNIO SSH support?
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ SwiftNIO SSH      | Minimum Swift Version
 `0.5.0 ..< 0.6.2` | 5.5.2
 `0.6.2 ..< 0.9.0` | 5.6
 `0.9.0 ..< 0.9.2` | 5.8
-`0.9.2 ...`       | 5.9
+`0.9.2 ..<`       | 5.9  **TODO:** Update version table
 
 ## What does SwiftNIO SSH support?
 


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
