### PR TITLE
Fix import guards in NIOSSHServer

### DIFF
--- a/Sources/NIOSSH/GlobalRequestDelegate.swift
+++ b/Sources/NIOSSH/GlobalRequestDelegate.swift
@@ -24,6 +24,8 @@ import NIOCore
 public protocol GlobalRequestDelegate {
     /// The client wants to manage TCP port forwarding.
     ///
+    /// The eventLoop associated with the promise passed in must be the same as the one used to create the handler.
+    ///
     /// The default implementation rejects all requests to establish TCP port forwarding.
     func tcpForwardingRequest(
         _: GlobalRequest.TCPForwardingRequest,

--- a/Sources/NIOSSHServer/DataToBufferCodec.swift
+++ b/Sources/NIOSSHServer/DataToBufferCodec.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Foundation.Process)
-
 import Dispatch
 import Foundation
 import NIOCore
@@ -21,14 +19,15 @@ import NIOFoundationCompat
 import NIOPosix
 import NIOSSH
 
-final class DataToBufferCodec: ChannelDuplexHandler {
+final class DataToBufferCodec: ChannelDuplexHandler, Sendable {
     typealias InboundIn = SSHChannelData
     typealias InboundOut = ByteBuffer
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = SSHChannelData
 
     func handlerAdded(context: ChannelHandlerContext) {
-        context.channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).whenFailure { error in
+        context.channel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true).assumeIsolated().whenFailure {
+            error in
             context.fireErrorCaught(error)
         }
     }
@@ -59,5 +58,3 @@ func createOutboundConnection(targetHost: String, targetPort: Int, loop: EventLo
         channel.eventLoop.makeSucceededFuture(())
     }.connect(host: targetHost, port: targetPort)
 }
-
-#endif  // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/GlueHandler.swift
+++ b/Sources/NIOSSHServer/GlueHandler.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Foundation.Process)
-
 import NIOCore
 
 final class GlueHandler {
@@ -124,5 +122,3 @@ extension GlueHandler: ChannelDuplexHandler {
         }
     }
 }
-
-#endif  // canImport(Foundation.Process)

--- a/Sources/NIOSSHServer/RemotePortForwarding.swift
+++ b/Sources/NIOSSHServer/RemotePortForwarding.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Foundation.Process)
-
 import Dispatch
 import Foundation
 import NIOCore
@@ -26,16 +24,19 @@ import NIOSSH
 // Please note that, as with the rest of this example, there are important security features missing from
 // this demo.
 final class RemotePortForwarder {
-    private var serverChannel: Channel?
+    private let serverChannel: Channel?
 
-    private var inboundSSHHandler: NIOSSHHandler
+    private let inboundSSHHandler: NIOSSHHandler
 
     init(inboundSSHHandler: NIOSSHHandler) {
         self.inboundSSHHandler = inboundSSHHandler
+        self.serverChannel = nil
     }
 
     func beginListening(on host: String, port: Int, loop: EventLoop) -> EventLoopFuture<Int?> {
-        ServerBootstrap(group: loop).serverChannelOption(
+        let loopBoundHandler = NIOLoopBound(inboundSSHHandler, eventLoop: loop)
+
+        return ServerBootstrap(group: loop).serverChannelOption(
             ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SocketOptionName(SO_REUSEADDR)),
             value: 1
         )
@@ -45,29 +46,33 @@ final class RemotePortForwarder {
             value: 1
         )
         .childChannelInitializer { childChannel in
-            let (ours, theirs) = GlueHandler.matchedPair()
-
-            // Ok, ask for the remote channel to be created. This needs remote half closure turned on and to be
-            // set up for data I/O.
-            let promise = loop.makePromise(of: Channel.self)
-            self.inboundSSHHandler.createChannel(
-                promise,
-                channelType: .forwardedTCPIP(
-                    .init(
-                        listeningHost: host,
-                        listeningPort: childChannel.localAddress!.port!,
-                        originatorAddress: childChannel.remoteAddress!
-                    )
-                )
-            ) { sshChildChannel, _ in
-                sshChildChannel.pipeline.addHandlers([DataToBufferCodec(), theirs]).flatMap {
-                    sshChildChannel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true)
-                }
-            }
-
             // Great, now we add the glue handler to the newly-accepted channel, and then we don't allow this channel to go
             // active until the SSH channel has. Both should go active at once.
-            return childChannel.pipeline.addHandler(ours).flatMap { _ in promise.futureResult }.map { _ in () }
+            childChannel.eventLoop.makeCompletedFuture {
+                let (ours, theirs) = GlueHandler.matchedPair()
+
+                // Ok, ask for the remote channel to be created. This needs remote half closure turned on and to be
+                // set up for data I/O.
+                let promise = loop.makePromise(of: Channel.self)
+                loopBoundHandler.value.createChannel(
+                    promise,
+                    channelType: .forwardedTCPIP(
+                        .init(
+                            listeningHost: host,
+                            listeningPort: childChannel.localAddress!.port!,
+                            originatorAddress: childChannel.remoteAddress!
+                        )
+                    )
+                ) { sshChildChannel, _ in
+                    sshChildChannel.eventLoop.makeCompletedFuture {
+                        try sshChildChannel.pipeline.syncOperations.addHandlers([DataToBufferCodec(), theirs])
+                        _ = sshChildChannel.setOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+                    }
+
+                }
+
+                try childChannel.pipeline.syncOperations.addHandler(ours)
+            }
         }
         .bind(host: host, port: port).map { channel in
             if port == 0 {
@@ -118,5 +123,3 @@ final class RemotePortForwarderGlobalRequestDelegate: GlobalRequestDelegate {
         self.forwarder?.stopListening()
     }
 }
-
-#endif  // canImport(Foundation.Process)


### PR DESCRIPTION
The `NIOSSHServer` example guards all of its code with `#if canImport(Foundation.Process)` to avoid build failures on platforms without Process. 

However, Swift doesn't have submodules like this, Objective-C does. As Foundation transitions to Swift this check now always fails, even if Process is available. The result of this is that example code doesn't compile with newer Swift versions. Removing the can-imports results in a handful of Sendability warnings.

I've removed the guards and fixed all of the resulting Sendability warnings.