### PR TITLE
Enable Swift 6.2 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,7 @@ jobs:
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
             linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 192599
+}

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 789999
+}

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 40768
+}


### PR DESCRIPTION
Motivation:

Swift 6.2 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.2 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
