### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,6 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
             linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 
 import PackageDescription
 

--- a/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 192635
-}

--- a/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 825999
-}

--- a/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/5.10/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 40804
-}

--- a/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal": 190603
-}

--- a/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal": 791999
-}

--- a/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.0/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal": 40772
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftNIO open source project

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SwiftNIO SSH        | Minimum Swift Version
 `0.9.0  ..< 0.9.2`  | 5.8
 `0.9.2  ..< 0.10.0` | 5.9
 `0.10.0 ... 0.12.0` | 5.10
-`0.12.0 ...`        | 6.0
+`0.12.0 ..<`        | 6.0  **TODO:** Update version table
 
 ## What does SwiftNIO SSH support?
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ SwiftNIO SSH        | Minimum Swift Version
 `0.9.0  ..< 0.9.2`  | 5.8
 `0.9.2  ..< 0.10.0` | 5.9
 `0.10.0 ... 0.12.0` | 5.10
-`0.12.0 ..<`        | 6.0  **TODO:** Update version table
+`0.12.0 ..< 0.13.0` | 6.0
+`0.13.0 ..<`        | 6.1
 
 ## What does SwiftNIO SSH support?
 


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
