### PR TITLE
Add mlkem768x25519-sha256 post-quantum hybrid KEX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
+        // 4.5.0 is the first release with the public `MLKEM768` API
+        // (`Sources/Crypto/KEM/MLKEM.swift`), used by
+        // `MLKEM768X25519KeyExchange` for the post-quantum hybrid KEX.
+        .package(url: "https://github.com/apple/swift-crypto.git", "4.5.0"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [

--- a/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
+++ b/Sources/NIOSSH/Key Exchange/EllipticCurveKeyExchange.swift
@@ -27,7 +27,7 @@ import Foundation
 protocol EllipticCurveKeyExchangeProtocol: _NIOSSHSendableMetatype {
     init(ourRole: SSHConnectionRole, previousSessionIdentifier: ByteBuffer?)
 
-    func initiateKeyExchangeClientSide(allocator: ByteBufferAllocator) -> SSHMessage.KeyExchangeECDHInitMessage
+    mutating func initiateKeyExchangeClientSide(allocator: ByteBufferAllocator) -> SSHMessage.KeyExchangeECDHInitMessage
 
     mutating func completeKeyExchangeServerSide(
         clientKeyExchangeMessage message: SSHMessage.KeyExchangeECDHInitMessage,

--- a/Sources/NIOSSH/Key Exchange/MLKEM768X25519KeyExchange.swift
+++ b/Sources/NIOSSH/Key Exchange/MLKEM768X25519KeyExchange.swift
@@ -1,0 +1,390 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIOCore
+import NIOFoundationCompat
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Post-quantum hybrid key exchange combining ML-KEM-768 (FIPS 203) with X25519.
+///
+/// Wire format and key derivation follow the IETF draft
+/// `draft-kampanakis-curdle-ssh-pq-ke` and OpenSSH 9.9's
+/// `mlkem768x25519-sha256` algorithm:
+///
+///   * Client init payload (single SSH string):
+///       `MLKEM768 encapsulation key (1184 B) || X25519 public key (32 B)`
+///   * Server reply payload (single SSH string):
+///       `MLKEM768 ciphertext (1088 B) || X25519 public key (32 B)`
+///   * Shared secret used by SSH:
+///       `K = SHA-256(MLKEM_SS || X25519_SS)` — encoded as `mpint`
+///   * Exchange-hash function: `SHA-256`
+///
+/// `K` is intentionally derived as a fixed-length SHA-256 digest so that an
+/// attacker who compromises only one of the two primitives still cannot
+/// recover the SSH session keys: ML-KEM contributes quantum resistance,
+/// X25519 contributes well-studied classical security. This "hybrid by
+/// hashing" matches OpenSSH 9.9.
+///
+/// > Important: This struct lazy-generates its ephemeral keypairs inside
+/// > `initiateKeyExchangeClientSide(allocator:)` and
+/// > `completeKeyExchangeServerSide(...)` because `MLKEM768.PrivateKey.init`
+/// > can throw and the existing `EllipticCurveKeyExchangeProtocol.init`
+/// > is neither throwing nor mutating. See the DRAFT PR description for the
+/// > follow-up question of whether the protocol should grow a throwing
+/// > variant or whether the lazy-generation pattern stays.
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, macCatalyst 26.0, visionOS 26.0, *)
+struct MLKEM768X25519KeyExchange: EllipticCurveKeyExchangeProtocol {
+    /// Size of an ML-KEM-768 encapsulation (public) key in bytes — FIPS 203 §8.
+    static let mlkemPublicKeySize = 1184
+
+    /// Size of an ML-KEM-768 ciphertext in bytes — FIPS 203 §8.
+    static let mlkemCiphertextSize = 1088
+
+    /// Size of an X25519 public key in bytes — RFC 7748 §6.1.
+    static let x25519PublicKeySize = 32
+
+    private var previousSessionIdentifier: ByteBuffer?
+    private var ourRole: SSHConnectionRole
+
+    // Client-only ephemeral state, populated during init.
+    private var clientX25519PrivateKey: Curve25519.KeyAgreement.PrivateKey?
+    private var clientMLKEMPrivateKey: MLKEM768.PrivateKey?
+
+    // Server-only ephemeral state, populated during completion.
+    private var serverX25519PrivateKey: Curve25519.KeyAgreement.PrivateKey?
+
+    // SHA-256 digest of (MLKEM_SS || X25519_SS), held as raw bytes so it can
+    // be fed into the SSH exchange hash as an `mpint`.
+    private var sharedSecretDigest: [UInt8]?
+
+    // Both payloads are echoed verbatim into the SSH exchange hash, so we
+    // hold onto them across the init/reply round-trip.
+    private var clientInitPayload: ByteBuffer?
+    private var serverReplyPayload: ByteBuffer?
+
+    init(ourRole: SSHConnectionRole, previousSessionIdentifier: ByteBuffer?) {
+        self.ourRole = ourRole
+        self.previousSessionIdentifier = previousSessionIdentifier
+    }
+
+    static var keyExchangeAlgorithmNames: [Substring] {
+        ["mlkem768x25519-sha256"]
+    }
+
+    // MARK: - Client side
+
+    mutating func initiateKeyExchangeClientSide(
+        allocator: ByteBufferAllocator
+    ) -> SSHMessage.KeyExchangeECDHInitMessage {
+        precondition(self.ourRole.isClient, "Only clients may initiate the client side key exchange!")
+
+        // ML-KEM-768 keygen is implemented as throwing in swift-crypto. The
+        // KEX state machine doesn't tolerate a throwing initiator, so we
+        // crash on the (theoretically unreachable) failure path. A future
+        // protocol revision could make this method throwing.
+        let x25519PrivateKey = Curve25519.KeyAgreement.PrivateKey()
+        let mlkemPrivateKey: MLKEM768.PrivateKey
+        do {
+            mlkemPrivateKey = try MLKEM768.PrivateKey()
+        } catch {
+            preconditionFailure("MLKEM768 keypair generation failed: \(error)")
+        }
+
+        self.clientX25519PrivateKey = x25519PrivateKey
+        self.clientMLKEMPrivateKey = mlkemPrivateKey
+
+        var payload = allocator.buffer(capacity: Self.mlkemPublicKeySize + Self.x25519PublicKeySize)
+        payload.writeBytes(mlkemPrivateKey.publicKey.rawRepresentation)
+        payload.writeBytes(x25519PrivateKey.publicKey.rawRepresentation)
+
+        self.clientInitPayload = payload
+        return .init(publicKey: payload)
+    }
+
+    mutating func receiveServerKeyExchangePayload(
+        serverKeyExchangeMessage message: SSHMessage.KeyExchangeECDHReplyMessage,
+        initialExchangeBytes: inout ByteBuffer,
+        allocator: ByteBufferAllocator,
+        expectedKeySizes: ExpectedKeySizes
+    ) throws -> KeyExchangeResult {
+        precondition(self.ourRole.isClient, "Only clients may receive a server key exchange packet!")
+
+        guard
+            let clientX25519PrivateKey = self.clientX25519PrivateKey,
+            let clientMLKEMPrivateKey = self.clientMLKEMPrivateKey,
+            let clientInitPayload = self.clientInitPayload
+        else {
+            preconditionFailure("receiveServerKeyExchangePayload called before initiateKeyExchangeClientSide")
+        }
+
+        var replyBytes = message.publicKey
+        guard replyBytes.readableBytes == Self.mlkemCiphertextSize + Self.x25519PublicKeySize else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+        self.serverReplyPayload = replyBytes
+
+        guard
+            let mlkemCiphertext = replyBytes.readBytes(length: Self.mlkemCiphertextSize),
+            let serverX25519PublicKeyBytes = replyBytes.readBytes(length: Self.x25519PublicKeySize)
+        else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        let mlkemSharedSecret = try clientMLKEMPrivateKey.decapsulate(mlkemCiphertext)
+        let serverX25519PublicKey = try Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: serverX25519PublicKeyBytes
+        )
+        let x25519SharedSecret = try clientX25519PrivateKey.sharedSecretFromKeyAgreement(
+            with: serverX25519PublicKey
+        )
+
+        self.deriveHybridSharedSecret(
+            mlkemSharedSecret: mlkemSharedSecret,
+            x25519SharedSecret: x25519SharedSecret
+        )
+
+        let (kexResult, exchangeHash) = self.finalizeKeyExchange(
+            clientInitPayload: clientInitPayload,
+            serverReplyPayload: self.serverReplyPayload!,
+            initialExchangeBytes: &initialExchangeBytes,
+            serverHostKey: message.hostKey,
+            allocator: allocator,
+            expectedKeySizes: expectedKeySizes
+        )
+
+        guard message.hostKey.isValidSignature(message.signature, for: exchangeHash) else {
+            throw NIOSSHError.invalidExchangeHashSignature
+        }
+
+        return kexResult
+    }
+
+    // MARK: - Server side
+
+    mutating func completeKeyExchangeServerSide(
+        clientKeyExchangeMessage message: SSHMessage.KeyExchangeECDHInitMessage,
+        serverHostKey: NIOSSHPrivateKey,
+        initialExchangeBytes: inout ByteBuffer,
+        allocator: ByteBufferAllocator,
+        expectedKeySizes: ExpectedKeySizes
+    ) throws -> (KeyExchangeResult, SSHMessage.KeyExchangeECDHReplyMessage) {
+        precondition(self.ourRole.isServer, "Only servers may receive a client key exchange packet!")
+
+        var initBytes = message.publicKey
+        guard initBytes.readableBytes == Self.mlkemPublicKeySize + Self.x25519PublicKeySize else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+        self.clientInitPayload = initBytes
+
+        guard
+            let mlkemPublicKeyBytes = initBytes.readBytes(length: Self.mlkemPublicKeySize),
+            let clientX25519PublicKeyBytes = initBytes.readBytes(length: Self.x25519PublicKeySize)
+        else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        let serverX25519PrivateKey = Curve25519.KeyAgreement.PrivateKey()
+        self.serverX25519PrivateKey = serverX25519PrivateKey
+
+        let mlkemPublicKey = try MLKEM768.PublicKey(rawRepresentation: mlkemPublicKeyBytes)
+        let encapsulation = try mlkemPublicKey.encapsulate()
+        let mlkemSharedSecret = encapsulation.sharedSecret
+        let mlkemCiphertext = encapsulation.encapsulated
+
+        let clientX25519PublicKey = try Curve25519.KeyAgreement.PublicKey(
+            rawRepresentation: clientX25519PublicKeyBytes
+        )
+        let x25519SharedSecret = try serverX25519PrivateKey.sharedSecretFromKeyAgreement(
+            with: clientX25519PublicKey
+        )
+
+        self.deriveHybridSharedSecret(
+            mlkemSharedSecret: mlkemSharedSecret,
+            x25519SharedSecret: x25519SharedSecret
+        )
+
+        guard mlkemCiphertext.count == Self.mlkemCiphertextSize else {
+            throw NIOSSHError.invalidEncryptedPacketLength
+        }
+
+        var replyPayload = allocator.buffer(capacity: Self.mlkemCiphertextSize + Self.x25519PublicKeySize)
+        replyPayload.writeBytes(mlkemCiphertext)
+        replyPayload.writeBytes(serverX25519PrivateKey.publicKey.rawRepresentation)
+        self.serverReplyPayload = replyPayload
+
+        let (kexResult, exchangeHash) = self.finalizeKeyExchange(
+            clientInitPayload: self.clientInitPayload!,
+            serverReplyPayload: replyPayload,
+            initialExchangeBytes: &initialExchangeBytes,
+            serverHostKey: serverHostKey.publicKey,
+            allocator: allocator,
+            expectedKeySizes: expectedKeySizes
+        )
+
+        let exchangeHashSignature = try serverHostKey.sign(digest: exchangeHash)
+        let responseMessage = SSHMessage.KeyExchangeECDHReplyMessage(
+            hostKey: serverHostKey.publicKey,
+            publicKey: replyPayload,
+            signature: exchangeHashSignature
+        )
+
+        return (kexResult, responseMessage)
+    }
+
+    // MARK: - Hybrid secret derivation
+
+    /// Folds the two component shared secrets into the SSH `K` value via
+    /// `SHA-256(MLKEM_SS || X25519_SS)`. Per the IETF draft, fixed-length
+    /// hashing prevents domain-separation issues and bounds `K` so subsequent
+    /// SSH key derivation behaves identically to other SHA-256 KEX methods.
+    private mutating func deriveHybridSharedSecret(
+        mlkemSharedSecret: SymmetricKey,
+        x25519SharedSecret: SharedSecret
+    ) {
+        var hasher = SHA256()
+        mlkemSharedSecret.withUnsafeBytes { hasher.update(bufferPointer: $0) }
+        x25519SharedSecret.withUnsafeBytes { hasher.update(bufferPointer: $0) }
+        self.sharedSecretDigest = Array(hasher.finalize())
+    }
+
+    // MARK: - SSH exchange-hash + session-key derivation
+
+    private func finalizeKeyExchange(
+        clientInitPayload: ByteBuffer,
+        serverReplyPayload: ByteBuffer,
+        initialExchangeBytes: inout ByteBuffer,
+        serverHostKey: NIOSSHPublicKey,
+        allocator: ByteBufferAllocator,
+        expectedKeySizes: ExpectedKeySizes
+    ) -> (KeyExchangeResult, SHA256.Digest) {
+        guard let sharedSecretDigest = self.sharedSecretDigest else {
+            preconditionFailure("finalizeKeyExchange called before deriveHybridSharedSecret")
+        }
+
+        initialExchangeBytes.writeCompositeSSHString {
+            $0.writeSSHHostKey(serverHostKey)
+        }
+
+        // Both client and server hash in payloads in the same canonical
+        // order: client init then server reply. This matches the IETF
+        // draft and how OpenSSH 9.9 computes the exchange hash.
+        var initPayloadCopy = clientInitPayload
+        var replyPayloadCopy = serverReplyPayload
+        initialExchangeBytes.writeCompositeSSHString { $0.writeBuffer(&initPayloadCopy) }
+        initialExchangeBytes.writeCompositeSSHString { $0.writeBuffer(&replyPayloadCopy) }
+
+        var hasher = SHA256()
+        hasher.update(data: initialExchangeBytes.readableBytesView)
+        Self.updateAsMPInt(&hasher, sharedSecretDigest: sharedSecretDigest)
+
+        let exchangeHash = hasher.finalize()
+
+        let sessionID: ByteBuffer
+        if let previousSessionIdentifier = self.previousSessionIdentifier {
+            sessionID = previousSessionIdentifier
+        } else {
+            var hashBytes = allocator.buffer(capacity: SHA256.Digest.byteCount)
+            hashBytes.writeContiguousBytes(exchangeHash)
+            sessionID = hashBytes
+        }
+
+        let keys = self.generateKeys(
+            sharedSecretDigest: sharedSecretDigest,
+            exchangeHash: exchangeHash,
+            sessionID: sessionID,
+            expectedKeySizes: expectedKeySizes
+        )
+
+        return (KeyExchangeResult(sessionID: sessionID, keys: keys), exchangeHash)
+    }
+
+    /// SSH's wire encoding for `K` is `mpint`: a length-prefixed big-endian
+    /// two's-complement integer. For a 32-byte SHA-256 digest, we just need
+    /// to insert a leading zero byte if the high bit is set so the value
+    /// reads as positive. The 4-byte length prefix is also part of the
+    /// hashed input per RFC 4253 §8.
+    private static func updateAsMPInt(_ hasher: inout SHA256, sharedSecretDigest: [UInt8]) {
+        let needsPadding = (sharedSecretDigest.first ?? 0) & 0x80 != 0
+        let length = UInt32(sharedSecretDigest.count + (needsPadding ? 1 : 0))
+        var lengthBE = length.bigEndian
+        withUnsafeBytes(of: &lengthBE) { hasher.update(bufferPointer: $0) }
+        if needsPadding {
+            hasher.update(data: [UInt8(0)])
+        }
+        hasher.update(data: sharedSecretDigest)
+    }
+
+    /// Implements RFC 4253 §7.2 with `HASH = SHA-256`. Derives the six
+    /// per-direction session keys (initial IVs, encryption keys, MAC keys)
+    /// from `K`, `H` and the session identifier.
+    private func generateKeys(
+        sharedSecretDigest: [UInt8],
+        exchangeHash: SHA256.Digest,
+        sessionID: ByteBuffer,
+        expectedKeySizes: ExpectedKeySizes
+    ) -> NIOSSHSessionKeys {
+        func deriveKey(letter: UInt8, expectedSize: Int) -> [UInt8] {
+            // K1 = HASH(K || H || letter || session_id)
+            var hasher = SHA256()
+            Self.updateAsMPInt(&hasher, sharedSecretDigest: sharedSecretDigest)
+            exchangeHash.withUnsafeBytes { hasher.update(bufferPointer: $0) }
+            hasher.update(data: [letter])
+            hasher.update(data: sessionID.readableBytesView)
+            var out = Array(hasher.finalize())
+            // K2 = HASH(K || H || K1); K3 = HASH(K || H || K1 || K2); ...
+            while out.count < expectedSize {
+                var extend = SHA256()
+                Self.updateAsMPInt(&extend, sharedSecretDigest: sharedSecretDigest)
+                exchangeHash.withUnsafeBytes { extend.update(bufferPointer: $0) }
+                extend.update(data: out)
+                out.append(contentsOf: extend.finalize())
+            }
+            return Array(out.prefix(expectedSize))
+        }
+
+        let ivCToS = deriveKey(letter: UInt8(ascii: "A"), expectedSize: expectedKeySizes.ivSize)
+        let ivSToC = deriveKey(letter: UInt8(ascii: "B"), expectedSize: expectedKeySizes.ivSize)
+        let encCToS = deriveKey(letter: UInt8(ascii: "C"), expectedSize: expectedKeySizes.encryptionKeySize)
+        let encSToC = deriveKey(letter: UInt8(ascii: "D"), expectedSize: expectedKeySizes.encryptionKeySize)
+        let macCToS = deriveKey(letter: UInt8(ascii: "E"), expectedSize: expectedKeySizes.macKeySize)
+        let macSToC = deriveKey(letter: UInt8(ascii: "F"), expectedSize: expectedKeySizes.macKeySize)
+
+        switch self.ourRole {
+        case .client:
+            return NIOSSHSessionKeys(
+                initialInboundIV: ivSToC,
+                initialOutboundIV: ivCToS,
+                inboundEncryptionKey: SymmetricKey(data: encSToC),
+                outboundEncryptionKey: SymmetricKey(data: encCToS),
+                inboundMACKey: SymmetricKey(data: macSToC),
+                outboundMACKey: SymmetricKey(data: macCToS)
+            )
+        case .server:
+            return NIOSSHSessionKeys(
+                initialInboundIV: ivCToS,
+                initialOutboundIV: ivSToC,
+                inboundEncryptionKey: SymmetricKey(data: encCToS),
+                outboundEncryptionKey: SymmetricKey(data: encSToC),
+                inboundMACKey: SymmetricKey(data: macCToS),
+                outboundMACKey: SymmetricKey(data: macSToC)
+            )
+        }
+    }
+}

--- a/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
+++ b/Sources/NIOSSH/Key Exchange/SSHKeyExchangeStateMachine.swift
@@ -152,7 +152,7 @@ struct SSHKeyExchangeStateMachine {
 
                 // verify algorithms
                 let negotiated = try self.negotiatedAlgorithms(message)
-                let exchanger = try self.exchangerForAlgorithm(negotiated.negotiatedKeyExchangeAlgorithm)
+                var exchanger = try self.exchangerForAlgorithm(negotiated.negotiatedKeyExchangeAlgorithm)
 
                 // Ok, we need to send the key exchange message.
                 let message = SSHMessage.keyExchangeInit(
@@ -188,7 +188,7 @@ struct SSHKeyExchangeStateMachine {
             }
 
             let negotiated = try self.negotiatedAlgorithms(message)
-            let exchanger = try self.exchangerForAlgorithm(negotiated.negotiatedKeyExchangeAlgorithm)
+            var exchanger = try self.exchangerForAlgorithm(negotiated.negotiatedKeyExchangeAlgorithm)
 
             let result: SSHMultiMessage
             switch self.role {
@@ -589,12 +589,22 @@ struct SSHKeyExchangeStateMachine {
 
 extension SSHKeyExchangeStateMachine {
     // For now this is a static list.
-    static let supportedKeyExchangeImplementations: [EllipticCurveKeyExchangeProtocol.Type] = [
-        EllipticCurveKeyExchange<P384.KeyAgreement.PrivateKey>.self,
-        EllipticCurveKeyExchange<P256.KeyAgreement.PrivateKey>.self,
-        EllipticCurveKeyExchange<P521.KeyAgreement.PrivateKey>.self,
-        EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>.self,
-    ]
+    static let supportedKeyExchangeImplementations: [EllipticCurveKeyExchangeProtocol.Type] = {
+        let classical: [EllipticCurveKeyExchangeProtocol.Type] = [
+            EllipticCurveKeyExchange<P384.KeyAgreement.PrivateKey>.self,
+            EllipticCurveKeyExchange<P256.KeyAgreement.PrivateKey>.self,
+            EllipticCurveKeyExchange<P521.KeyAgreement.PrivateKey>.self,
+            EllipticCurveKeyExchange<Curve25519.KeyAgreement.PrivateKey>.self,
+        ]
+        if #available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, macCatalyst 26.0, visionOS 26.0, *) {
+            // Post-quantum hybrid first: OpenSSH 9.9+ peers prefer it, and
+            // classical-only peers will fall through to curve25519-sha256
+            // via standard SSH algorithm negotiation.
+            return [MLKEM768X25519KeyExchange.self] + classical
+        } else {
+            return classical
+        }
+    }()
 
     static let supportedKeyExchangeAlgorithms: [Substring] = supportedKeyExchangeImplementations.flatMap {
         $0.keyExchangeAlgorithmNames

--- a/Tests/NIOSSHTests/MLKEM768X25519KeyExchangeTests.swift
+++ b/Tests/NIOSSHTests/MLKEM768X25519KeyExchangeTests.swift
@@ -1,0 +1,160 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftNIO open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftNIO project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import NIOCore
+import XCTest
+
+@testable import NIOSSH
+
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, macCatalyst 26.0, visionOS 26.0, *)
+final class MLKEM768X25519KeyExchangeTests: XCTestCase {
+    private func keyExchangeAgreed(_ first: KeyExchangeResult, _ second: KeyExchangeResult) {
+        XCTAssertEqual(first.sessionID, second.sessionID)
+        XCTAssertEqual(first.keys.initialInboundIV, second.keys.initialOutboundIV)
+        XCTAssertEqual(first.keys.initialOutboundIV, second.keys.initialInboundIV)
+        XCTAssertEqual(first.keys.inboundEncryptionKey, second.keys.outboundEncryptionKey)
+        XCTAssertEqual(first.keys.outboundEncryptionKey, second.keys.inboundEncryptionKey)
+        XCTAssertEqual(first.keys.inboundMACKey, second.keys.outboundMACKey)
+        XCTAssertEqual(first.keys.outboundMACKey, second.keys.inboundMACKey)
+    }
+
+    func testRoundTripProducesMatchingKeys() throws {
+        var server = MLKEM768X25519KeyExchange(
+            ourRole: .mlkemTest_server([.init(ed25519Key: .init())]),
+            previousSessionIdentifier: nil
+        )
+        var client = MLKEM768X25519KeyExchange(ourRole: .mlkemTest_client, previousSessionIdentifier: nil)
+        let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
+
+        var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 4096)
+
+        let clientMessage = client.initiateKeyExchangeClientSide(allocator: ByteBufferAllocator())
+
+        // Per OpenSSH 9.9 wire format: client init payload is MLKEM768 public
+        // key (1184 B) || X25519 public key (32 B).
+        XCTAssertEqual(
+            clientMessage.publicKey.readableBytes,
+            MLKEM768X25519KeyExchange.mlkemPublicKeySize + MLKEM768X25519KeyExchange.x25519PublicKeySize
+        )
+
+        let (serverKeys, serverResponse) = try server.completeKeyExchangeServerSide(
+            clientKeyExchangeMessage: clientMessage,
+            serverHostKey: serverHostKey,
+            initialExchangeBytes: &initialExchangeBytes,
+            allocator: ByteBufferAllocator(),
+            expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes
+        )
+
+        // Server reply payload is MLKEM768 ciphertext (1088 B) || X25519
+        // public key (32 B).
+        XCTAssertEqual(
+            serverResponse.publicKey.readableBytes,
+            MLKEM768X25519KeyExchange.mlkemCiphertextSize + MLKEM768X25519KeyExchange.x25519PublicKeySize
+        )
+
+        initialExchangeBytes.clear()
+
+        let clientKeys = try client.receiveServerKeyExchangePayload(
+            serverKeyExchangeMessage: serverResponse,
+            initialExchangeBytes: &initialExchangeBytes,
+            allocator: ByteBufferAllocator(),
+            expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes
+        )
+
+        self.keyExchangeAgreed(serverKeys, clientKeys)
+    }
+
+    func testReusesPreviousSessionIdentifier() throws {
+        var previousSessionIdentifier = ByteBufferAllocator().buffer(capacity: 32)
+        previousSessionIdentifier.writeBytes(0..<32)
+
+        var server = MLKEM768X25519KeyExchange(
+            ourRole: .mlkemTest_server([.init(ed25519Key: .init())]),
+            previousSessionIdentifier: previousSessionIdentifier
+        )
+        var client = MLKEM768X25519KeyExchange(
+            ourRole: .mlkemTest_client,
+            previousSessionIdentifier: previousSessionIdentifier
+        )
+        let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
+
+        var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 4096)
+
+        let clientMessage = client.initiateKeyExchangeClientSide(allocator: ByteBufferAllocator())
+        let (serverKeys, serverResponse) = try server.completeKeyExchangeServerSide(
+            clientKeyExchangeMessage: clientMessage,
+            serverHostKey: serverHostKey,
+            initialExchangeBytes: &initialExchangeBytes,
+            allocator: ByteBufferAllocator(),
+            expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes
+        )
+
+        initialExchangeBytes.clear()
+
+        let clientKeys = try client.receiveServerKeyExchangePayload(
+            serverKeyExchangeMessage: serverResponse,
+            initialExchangeBytes: &initialExchangeBytes,
+            allocator: ByteBufferAllocator(),
+            expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes
+        )
+
+        self.keyExchangeAgreed(serverKeys, clientKeys)
+        XCTAssertEqual(serverKeys.sessionID, previousSessionIdentifier)
+    }
+
+    func testRejectsTruncatedClientInit() throws {
+        var server = MLKEM768X25519KeyExchange(
+            ourRole: .mlkemTest_server([.init(ed25519Key: .init())]),
+            previousSessionIdentifier: nil
+        )
+        let serverHostKey = NIOSSHPrivateKey(ed25519Key: .init())
+        var initialExchangeBytes = ByteBufferAllocator().buffer(capacity: 4096)
+
+        var shortPayload = ByteBufferAllocator().buffer(capacity: 100)
+        shortPayload.writeBytes(repeatElement(UInt8(0), count: 100))
+        let badMessage = SSHMessage.KeyExchangeECDHInitMessage(publicKey: shortPayload)
+
+        XCTAssertThrowsError(
+            try server.completeKeyExchangeServerSide(
+                clientKeyExchangeMessage: badMessage,
+                serverHostKey: serverHostKey,
+                initialExchangeBytes: &initialExchangeBytes,
+                allocator: ByteBufferAllocator(),
+                expectedKeySizes: AES128GCMOpenSSHTransportProtection.keySizes
+            )
+        )
+    }
+
+    func testAlgorithmName() {
+        XCTAssertEqual(MLKEM768X25519KeyExchange.keyExchangeAlgorithmNames, ["mlkem768x25519-sha256"])
+    }
+}
+
+/// Mirrors the helper in `ECKeyExchangeTests.swift` — kept fileprivate
+/// so it doesn't collide with that file's `extension SSHConnectionRole`.
+extension SSHConnectionRole {
+    fileprivate static func mlkemTest_server(_ hostKeys: [NIOSSHPrivateKey]) -> SSHConnectionRole {
+        .server(SSHServerConfiguration(hostKeys: hostKeys, userAuthDelegate: DenyAllServerAuthDelegate()))
+    }
+
+    fileprivate static var mlkemTest_client: SSHConnectionRole {
+        .client(
+            SSHClientConfiguration(
+                userAuthDelegate: ExplodingAuthDelegate(),
+                serverAuthDelegate: AcceptAllHostKeysDelegate()
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Motivation

OpenSSH 9.9+ ships `mlkem768x25519-sha256` as its default key exchange,
giving SSH transport sessions resistance to harvest-now-decrypt-later
attacks against a future cryptographically-relevant quantum computer.
swift-nio-ssh currently only supports classical ECDH primitives
(curve25519-sha256, ecdh-sha2-nistp256/384/521), so any iOS or macOS
client built on it (e.g. Termius-style apps using Citadel, or anything
embedding NIOSSH directly) is left behind whenever it talks to a modern
sshd.

Apple shipped the `MLKEM768` primitive in
[swift-crypto 4.5.0](https://github.com/apple/swift-crypto/blob/4.5.0/Sources/Crypto/KEM/MLKEM.swift)
(public `MLKEM768.PublicKey` / `MLKEM768.PrivateKey` with
`encapsulate()` / `decapsulate()`), so the underlying KEM is now
available without any FFI, BoringSSL detour, or third-party dependency
— only the SSH wire-format integration was missing. This PR adds that
integration.

## What this PR does

1. New file ` Sources/NIOSSH/Key Exchange/MLKEM768X25519KeyExchange.swift`
   implementing `EllipticCurveKeyExchangeProtocol` for the hybrid:
   - **Client init payload** (single SSH string):
     \`MLKEM768 encapsulation key (1184 B) || X25519 public key (32 B)\`
   - **Server reply payload** (single SSH string):
     \`MLKEM768 ciphertext (1088 B) || X25519 public key (32 B)\`
   - **Shared secret**: \`K = SHA-256(MLKEM_SS || X25519_SS)\`,
     hashed in as an \`mpint\` per RFC 4253 §8
   - **Exchange-hash function**: SHA-256
   - **RFC 4253 §7.2** key derivation reimplemented for SHA-256
2. Registered at the top of \`SSHKeyExchangeStateMachine.supportedKeyExchangeImplementations\`,
   gated on \`#available(macOS 26.0, iOS 26.0, ...)\` (the deployment-target
   floor for the backing CryptoKit primitive). Classical peers
   transparently fall through to \`curve25519-sha256\`.
3. \`Package.swift\` swift-crypto floor bumped from \`1.0.0\` → \`4.5.0\`
   for the public \`MLKEM768\` API. This is a breaking change for
   downstream consumers still on older swift-crypto — flagging it
   explicitly so maintainers can decide whether to phase it in
   differently.
4. Tests: round-trip, previous-session-identifier reuse, truncated
   client-init rejection, algorithm-name spelling.

## Spec references

- IETF draft: [\`draft-kampanakis-curdle-ssh-pq-ke\`](https://datatracker.ietf.org/doc/draft-kampanakis-curdle-ssh-pq-ke/)
- OpenSSH 9.9 release notes (algorithm now default): https://www.openssh.com/txt/release-9.9
- FIPS 203 (ML-KEM): https://csrc.nist.gov/pubs/fips/203/final
- RFC 4253 §7/§8 (key derivation and \`mpint\` encoding)

## Open design questions for maintainers

**(1) Mutating + throwing initiateKeyExchangeClientSide**

\`MLKEM768.PrivateKey.init()\` is \`throws\`, but
\`EllipticCurveKeyExchangeProtocol.init\` is neither throwing nor
mutating. To avoid changing the protocol surface, this PR:
- bumps \`initiateKeyExchangeClientSide(allocator:)\` to
  \`mutating func\` on the protocol (a backwards-compatible widening —
  existing non-mutating ECDH conformers still work)
- lazy-generates the ML-KEM keypair inside that method and
  \`preconditionFailure\`s on the (theoretically unreachable)
  generation-failure path

A cleaner long-term shape would be a \`throws\` variant or moving
keypair generation into a separately-throwing init. Happy to refactor
in whichever direction you prefer.

**(2) swift-crypto floor bump**

\`MLKEM768\` is only available on swift-crypto >= 4.5.0, and the actual
primitive routes through CryptoKit on the macOS 26 / iOS 26 family
(hence the \`#available\` gate). Older deployment targets will compile,
link, and simply not register the hybrid algorithm — \`mlkem768x25519-sha256\`
silently drops out of the negotiation list. Is that the policy you'd
want, or should the gate fail loudly?

**(3) ML-KEM-1024 follow-up**

swift-crypto 4.5.0 also exposes \`MLKEM1024\`. OpenSSH hasn't
standardized an \`mlkem1024x25519-sha384\` algorithm name, but if you'd
like a 1024-variant for higher security margin I can extend the same
pattern in a follow-up.

## Status

Opening as **DRAFT** — the implementation builds clean and the new
test target passes (\`swift test --filter MLKEM768X25519KeyExchangeTests\`),
but I want maintainer feedback on the design questions above before
I sand the rough edges (interop tests against an OpenSSH 9.9 server,
fuzz coverage, additional KAT vectors, etc.). Happy to iterate.

## Verification

- \`swift build\` — green
- \`swift test --filter MLKEM768X25519KeyExchangeTests\` — 4/4 green
- \`swift test --filter KeyExchangeTests\` (existing ECDH suite) — 14/14 green; no regressions

— Wellington Mukahiwa (@Wellz26)