### PR TITLE
Fix readVersion() crash on bare LF as first byte (#237)

### DIFF
--- a/Sources/NIOSSH/SSHPacketParser.swift
+++ b/Sources/NIOSSH/SSHPacketParser.swift
@@ -130,8 +130,14 @@ struct SSHPacketParser {
             // Looking for a string ending with \r\n
             let slice = self.buffer.readableBytesView
             if let lfIndex = slice.firstIndex(of: lineFeed), lfIndex < slice.endIndex {
-                let versionEndIndex =
-                    slice[lfIndex.advanced(by: -1)] == carriageReturn ? lfIndex.advanced(by: -1) : lfIndex
+                // Guard the `-1` lookup: when the LF is the very first byte of
+                // the slice (e.g., a client sends a bare LF as its first byte
+                // after the TCP handshake), `lfIndex.advanced(by: -1)` would
+                // index before the buffer start and trap.
+                let endsWithCR =
+                    lfIndex > slice.startIndex
+                    && slice[lfIndex.advanced(by: -1)] == carriageReturn
+                let versionEndIndex = endsWithCR ? lfIndex.advanced(by: -1) : lfIndex
                 let version = String(decoding: slice[slice.startIndex..<versionEndIndex], as: UTF8.self)
                 self.buffer.moveReaderIndex(forwardBy: slice.startIndex.distance(to: lfIndex).advanced(by: 1))
                 return version

--- a/Tests/NIOSSHTests/SSHPacketParserTests.swift
+++ b/Tests/NIOSSHTests/SSHPacketParserTests.swift
@@ -134,6 +134,27 @@ final class SSHPacketParserTests: XCTestCase {
         }
     }
 
+    func testReadVersionLineFeedFirstByteOnServer() throws {
+        // Regression test for the crash described in #237. SSHPacketParser
+        // previously accessed `slice[lfIndex.advanced(by: -1)]` without
+        // checking that `lfIndex > slice.startIndex`, so a client sending a
+        // bare LF as its first byte after the TCP handshake trapped the
+        // process. Per the existing server-branch semantics (everything
+        // before the first LF is the version line), a leading LF should
+        // simply yield an empty version string and not crash.
+        var parser = SSHPacketParser(isServer: true, allocator: ByteBufferAllocator())
+
+        var part1 = ByteBuffer.of(string: "\n")
+        parser.append(bytes: &part1)
+
+        switch try parser.nextPacket() {
+        case .version(let string):
+            XCTAssertEqual(string, "")
+        default:
+            XCTFail("Expecting .version")
+        }
+    }
+
     func testReadVersionWithExtraLinesWithoutCarriageReturnOnServer() throws {
         var parser = SSHPacketParser(isServer: true, allocator: ByteBufferAllocator())
 


### PR DESCRIPTION
Closes #237.

`SSHPacketParser.readVersion()` in the server branch accessed
`slice[lfIndex.advanced(by: -1)]` without checking that
`lfIndex > slice.startIndex`. A client whose first byte after the TCP
handshake is a bare `\n` made the subscript index before the buffer
start, trapping the NIO event-loop thread with `EXC_BREAKPOINT` and
taking down the whole server process. Reproducible with
`printf '\n' | nc <host> <port>`.

## The fix

One-line guard on the `-1` access. A leading LF now yields an empty
version string, which is consistent with the existing server-branch
convention that everything before the first LF is the version line.

## Client branch

Unaffected — `slice.starts(with: \"SSH-\".utf8)` is checked first,
which guarantees `lfIndex >= 4 > slice.startIndex`.

## Test

Added `testReadVersionLineFeedFirstByteOnServer`. Verified that the
test reproduces the production crash signature
(`NIOCore/ByteBuffer-views.swift:80: Fatal error: index -1 out of range`)
without the fix, and passes with it. All 12 existing `SSHPacketParserTests`
still pass.

## Background

Reported in #237 after we hit this in production after ~4 days of
uptime on a public SSH port.