### PR TITLE
Don't crash on window adjust for a closed child channel

### DIFF
--- a/Sources/NIOSSH/Child Channels/ChildChannelStateMachine.swift
+++ b/Sources/NIOSSH/Child Channels/ChildChannelStateMachine.swift
@@ -493,7 +493,16 @@ extension ChildChannelStateMachine {
             // In the idle state we haven't either sent a channel open or received one. This is not really possible.
             preconditionFailure("Somehow received channel EOF for idle channel")
 
-        case .requestedLocally, .requestedRemotely, .closedLocally, .closedRemotely, .closed:
+        case .closedLocally, .closedRemotely, .closed:
+            // A read can be delivered from the multiplexer's pending-read queue
+            // after the channel was closed; the resulting window adjust must not
+            // crash the process. Surface it as a protocol error instead.
+            throw NIOSSHError.protocolViolation(
+                protocolName: "channel",
+                violation: "Sent channel window adjust on closed channel."
+            )
+
+        case .requestedLocally, .requestedRemotely:
             preconditionFailure("Sent channel window adjust on channel in invalid state")
         }
     }


### PR DESCRIPTION
## Problem

`ChildChannelStateMachine.sendChannelWindowAdjust` calls `preconditionFailure("Sent channel window adjust on channel in invalid state")` for the `closedLocally`, `closedRemotely`, and `closed` states. Since `preconditionFailure` is fatal, hitting any of those states crashes the entire process.

This is reachable in normal operation. On a multiplexed session, a read can be delivered from the multiplexer's pending-read queue *after* the child channel has been closed locally (for example, the application cancels or closes a channel while reads are still in flight). Servicing that buffered read advances the inbound window and triggers an outbound window adjust, by which point the child channel state machine is already in a closed state, so the precondition fires and the whole process dies.

### Stack summary

```
fatalError / preconditionFailure
  ChildChannelStateMachine.sendChannelWindowAdjust(...)   <- closedLocally / closedRemotely / closed
  SSHChildChannel (servicing a pending read after local close)
  SSHChannelMultiplexer (draining the pending-read queue)
```

## Fix

`sendChannelWindowAdjust` already `throws`, so the closed states do not need to be fatal. For `closedLocally`, `closedRemotely`, and `closed` we now throw `NIOSSHError.protocolViolation` instead of calling `preconditionFailure`. The caller fails the associated promise and errors the channel, which is already closing, so the outcome is a clean, contained error rather than process death.

`requestedLocally` and `requestedRemotely` keep the existing `preconditionFailure`, since reaching those states here genuinely indicates an internal logic error.

## Testing

- `swift build` succeeds.
- `swift test` passes (320 tests, 0 failures).

I understand the Swift project may require a CLA; happy to sign it.
