### PR TITLE
Adopt renamed benchmark package and update numbers

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -10,20 +10,20 @@ let package = Package(
     dependencies: [
         .package(path: "../"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.56.0"),
-        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.22.0"),
+        .package(url: "https://github.com/ordo-one/benchmark.git", from: "1.22.0"),
     ],
     targets: [
         .executableTarget(
             name: "NIOSSHBenchmarks",
             dependencies: [
-                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Benchmark", package: "benchmark"),
                 .product(name: "NIOSSH", package: "swift-nio-ssh"),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOEmbedded", package: "swift-nio"),
             ],
             path: "Benchmarks/NIOSSHBenchmarks",
             plugins: [
-                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+                .plugin(name: "BenchmarkPlugin", package: "benchmark")
             ]
         )
     ]

--- a/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 190603
+  "mallocCountTotal": 190655
 }

--- a/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 791999
+  "mallocCountTotal": 792051
 }

--- a/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40772
+  "mallocCountTotal": 40799
 }

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 190563
+  "mallocCountTotal": 190591
 }

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 751999
+  "mallocCountTotal": 752035
 }

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40732
+  "mallocCountTotal": 40735
 }

--- a/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.ManySmallCommandsPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 190563
+  "mallocCountTotal": 190567
 }

--- a/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
+++ b/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.OneCommandPerConnection.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 751999
+  "mallocCountTotal": 755999
 }

--- a/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40732
+  "mallocCountTotal": 40736
 }


### PR DESCRIPTION
### Motivation

The package-benchmark repository was renamed to benchmark. The also switched form jemalloc to a custom malloc interposer. This could affect the allocation counts.

### Modifications

* Adopt new package name in the benchmarks.
* Update benchmark thresholds.

### Results

Pass benchmarks in CI.