### PR TITLE
Configurable max packet size

### DIFF
--- a/Benchmarks/Benchmarks/NIOSSHBenchmarks/StreamingLargeMessageInSmallChunks.swift
+++ b/Benchmarks/Benchmarks/NIOSSHBenchmarks/StreamingLargeMessageInSmallChunks.swift
@@ -105,14 +105,17 @@ func runStreamingLargeMessageInSmallChunks(numberOfChunks: Int) throws {
             inboundChildChannelInitializer: nil
         )
     ).wait()
+
+    var config: SSHServerConfiguration = .init(
+        hostKeys: [hostKey],
+        userAuthDelegate: HardcodedServerPasswordDelegate()
+    )
+
+    config.maximumPacketSize = 1 << 24
+
     try serverChannel.pipeline.addHandler(
         NIOSSHHandler(
-            role: .server(
-                .init(
-                    hostKeys: [hostKey],
-                    userAuthDelegate: HardcodedServerPasswordDelegate()
-                )
-            ),
+            role: .server(config),
             allocator: serverChannel.allocator,
             inboundChildChannelInitializer: { channel, _ in
                 channel.pipeline.addHandler(ServerHandler())

--- a/Benchmarks/Benchmarks/NIOSSHBenchmarks/StreamingLargeMessageInSmallChunks.swift
+++ b/Benchmarks/Benchmarks/NIOSSHBenchmarks/StreamingLargeMessageInSmallChunks.swift
@@ -105,17 +105,14 @@ func runStreamingLargeMessageInSmallChunks(numberOfChunks: Int) throws {
             inboundChildChannelInitializer: nil
         )
     ).wait()
-
-    var config: SSHServerConfiguration = .init(
-        hostKeys: [hostKey],
-        userAuthDelegate: HardcodedServerPasswordDelegate()
-    )
-
-    config.maximumPacketSize = 1 << 24
-
     try serverChannel.pipeline.addHandler(
         NIOSSHHandler(
-            role: .server(config),
+            role: .server(
+                .init(
+                    hostKeys: [hostKey],
+                    userAuthDelegate: HardcodedServerPasswordDelegate()
+                )
+            ),
             allocator: serverChannel.allocator,
             inboundChildChannelInitializer: { channel, _ in
                 channel.pipeline.addHandler(ServerHandler())

--- a/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.1/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40799
+  "mallocCountTotal": 41471
 }

--- a/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.2/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40735
+  "mallocCountTotal": 41439
 }

--- a/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
+++ b/Benchmarks/Thresholds/6.3/NIOSSHBenchmarks.StreamingLargeMessageInSmallChunks.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal": 40735
+  "mallocCountTotal": 41431
 }

--- a/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
@@ -34,10 +34,14 @@ final class SSHChannelMultiplexer {
     /// Whether new channels are allowed. Set to `false` once the parent channel is shut down at the TCP level.
     private var canCreateNewChannels: Bool
 
+    /// The maximum channel data payload size we advertise to peers when opening channels.
+    private let maximumPacketSize: UInt32
+
     init(
         delegate: SSHMultiplexerDelegate,
         allocator: ByteBufferAllocator,
-        childChannelInitializer: SSHChildChannel.Initializer?
+        childChannelInitializer: SSHChildChannel.Initializer?,
+        maximumPacketSize: UInt32
     ) {
         self.channels = [:]
         self.channels.reserveCapacity(8)
@@ -47,6 +51,7 @@ final class SSHChannelMultiplexer {
         self.allocator = allocator
         self.childChannelInitializer = childChannelInitializer
         self.canCreateNewChannels = true
+        self.maximumPacketSize = maximumPacketSize
     }
 
     // Time to clean up. We drop references to things that may be keeping us alive.
@@ -201,15 +206,20 @@ extension SSHChannelMultiplexer {
             self.nextChannelID = 0
         }
 
-        // TODO: Make the window management parameters configurable
+        var (windowsize, overflow) = Int(self.maximumPacketSize).multipliedReportingOverflow(by: Constants.channelWindowSizePacketMultiple)
+        if overflow || windowsize > Int32.max {
+            windowsize = Int(Int32.max)
+        }
+
         let channel = SSHChildChannel(
             allocator: self.allocator,
             parent: parentChannel,
             multiplexer: self,
             initializer: initializer,
             localChannelID: channelID,
-            targetWindowSize: 1 << 24,
-            initialOutboundWindowSize: 0
+            targetWindowSize: Int32(windowsize),
+            initialOutboundWindowSize: 0,
+            maximumPacketSize: self.maximumPacketSize
         )  // The initial outbound window size is presumed to be 0 until we're told otherwise.
 
         self.channels[channelID] = channel

--- a/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChannelMultiplexer.swift
@@ -206,7 +206,9 @@ extension SSHChannelMultiplexer {
             self.nextChannelID = 0
         }
 
-        var (windowsize, overflow) = Int(self.maximumPacketSize).multipliedReportingOverflow(by: Constants.channelWindowSizePacketMultiple)
+        var (windowsize, overflow) = Int(self.maximumPacketSize).multipliedReportingOverflow(
+            by: Constants.channelWindowSizePacketMultiple
+        )
         if overflow || windowsize > Int32.max {
             windowsize = Int(Int32.max)
         }

--- a/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
+++ b/Sources/NIOSSH/Child Channels/SSHChildChannel.swift
@@ -82,6 +82,9 @@ final class SSHChildChannel {
     /// The max message size set by the peer. We initialize it to zero to begin with.
     private var peerMaxMessageSize: UInt32
 
+    /// The maximum channel data payload size we advertise to the peer when opening this channel.
+    private let maximumPacketSize: UInt32
+
     private var activationState: ActivationState
 
     // MARK: Stored properties for channel/channelcore conformance.
@@ -114,7 +117,8 @@ final class SSHChildChannel {
         initializer: Initializer?,
         localChannelID: UInt32,
         targetWindowSize: Int32,
-        initialOutboundWindowSize: UInt32
+        initialOutboundWindowSize: UInt32,
+        maximumPacketSize: UInt32
     ) {
         self.init(
             allocator: allocator,
@@ -123,7 +127,8 @@ final class SSHChildChannel {
             initializer: initializer,
             initialState: .init(localChannelID: localChannelID),
             targetWindowSize: targetWindowSize,
-            initialOutboundWindowSize: initialOutboundWindowSize
+            initialOutboundWindowSize: initialOutboundWindowSize,
+            maximumPacketSize: maximumPacketSize
         )
     }
 
@@ -134,7 +139,8 @@ final class SSHChildChannel {
         initializer: Initializer?,
         initialState: ChildChannelStateMachine,
         targetWindowSize: Int32,
-        initialOutboundWindowSize: UInt32
+        initialOutboundWindowSize: UInt32,
+        maximumPacketSize: UInt32
     ) {
         self.allocator = allocator
         self.closePromise = parent.eventLoop.makePromise()
@@ -151,6 +157,7 @@ final class SSHChildChannel {
             parentIsWritable: parent.isWritable
         )
         self.peerMaxMessageSize = 0
+        self.maximumPacketSize = maximumPacketSize
 
         // To begin with we initialize autoRead and halfClosure to false, but we are going to fetch it from our parent before we
         // go much further.
@@ -490,7 +497,7 @@ extension SSHChildChannel: Channel, ChannelCore {
                 recipientChannel: self.state.remoteChannelIdentifier!,
                 senderChannel: self.state.localChannelIdentifier,
                 initialWindowSize: self.windowManager.targetWindowSize,
-                maximumPacketSize: Constants.maximumChannelPacketSize
+                maximumPacketSize: self.maximumPacketSize
             )
             self.processOutboundMessage(.channelOpenConfirmation(message), promise: nil)
             self.writePendingToMultiplexer()
@@ -500,7 +507,7 @@ extension SSHChildChannel: Channel, ChannelCore {
                 type: .init(self.type!),
                 senderChannel: self.state.localChannelIdentifier,
                 initialWindowSize: self.windowManager.targetWindowSize,
-                maximumPacketSize: Constants.maximumChannelPacketSize
+                maximumPacketSize: self.maximumPacketSize
             )
             self.processOutboundMessage(.channelOpen(message), promise: nil)
             self.writePendingToMultiplexer()

--- a/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
+++ b/Sources/NIOSSH/Connection State Machine/States/SentVersionState.swift
@@ -35,7 +35,11 @@ extension SSHConnectionStateMachine {
             self.serializer = state.serializer
             self.protectionSchemes = state.protectionSchemes
 
-            self.parser = SSHPacketParser(isServer: self.role.isServer, allocator: allocator)
+            self.parser = SSHPacketParser(
+                isServer: self.role.isServer,
+                allocator: allocator,
+                maximumPacketSize: self.role.maximumPacketSize
+            )
             self.allocator = allocator
         }
 

--- a/Sources/NIOSSH/Constants.swift
+++ b/Sources/NIOSSH/Constants.swift
@@ -15,10 +15,20 @@
 public enum Constants: Sendable {
     static let version = "SSH-2.0-SwiftNIOSSH_1.0"
 
-    /// The maximum size, in bytes, of a channel data payload that we advertise we are willing to
-    /// receive (the "maximum packet size" of an SSH channel, RFC 4254 §5.1).
-    /// - Note: "This is a weirdly hard-coded choice."
-    static let maximumChannelPacketSize: UInt32 = 1 << 24
+    /// The default maximum size, in bytes, of a channel data payload that we advertise we are
+    /// willing to receive (the "maximum packet size" of an SSH channel, RFC 4254 §5.1). The RFC
+    /// does not set a maximum. Used when a connection does not override it via `maximumPacketSize`
+    /// on its configuration.
+    static let defaultMaximumChannelPacketSize: Int = 1 << 17
+
+    /// The smallest channel "maximum packet size" we permit a connection to be configured with.
+    /// RFC 4253 §6.1 requires every implementation to be able to process an uncompressed payload of
+    /// 32768 bytes, so advertising less than this would claim we cannot handle a spec-compliant peer.
+    static let minimumChannelPacketSize: Int = 32768
+
+    /// The per-channel receive window we advertise, as a multiple of the maximum packet size, so the
+    /// two stay coupled. Matches the multiplier used by OpenSSH.
+    static let channelWindowSizePacketMultiple = 64
 
     public static let bundledTransportProtectionSchemes: [(NIOSSHTransportProtection & _NIOSSHSendableMetatype).Type] =
         [

--- a/Sources/NIOSSH/Constants.swift
+++ b/Sources/NIOSSH/Constants.swift
@@ -26,6 +26,10 @@ public enum Constants: Sendable {
     /// 32768 bytes, so advertising less than this would claim we cannot handle a spec-compliant peer.
     static let minimumChannelPacketSize: Int = 32768
 
+    /// The maximum configurable channel packet size. Include headroom in packets for SSH framing
+    /// and padding (RFC 4253 §6).
+    static let maximumChannelPacketSize = UInt32.max - 1024
+
     /// The per-channel receive window we advertise, as a multiple of the maximum packet size, so the
     /// two stay coupled. Matches the multiplier used by OpenSSH.
     static let channelWindowSizePacketMultiple = 64

--- a/Sources/NIOSSH/NIOSSHHandler.swift
+++ b/Sources/NIOSSH/NIOSSHHandler.swift
@@ -83,7 +83,8 @@ public final class NIOSSHHandler {
         self.multiplexer = SSHChannelMultiplexer(
             delegate: self,
             allocator: allocator,
-            childChannelInitializer: inboundChildChannelInitializer
+            childChannelInitializer: inboundChildChannelInitializer,
+            maximumPacketSize: role.maximumPacketSize
         )
     }
 }

--- a/Sources/NIOSSH/Role.swift
+++ b/Sources/NIOSSH/Role.swift
@@ -52,9 +52,9 @@ public enum SSHConnectionRole {
     internal var maximumPacketSize: UInt32 {
         switch self {
         case .client(let configuration):
-            return UInt32(configuration.maximumPacketSize)
+            return UInt32(truncatingIfNeeded: configuration.maximumPacketSize)
         case .server(let configuration):
-            return UInt32(configuration.maximumPacketSize)
+            return UInt32(truncatingIfNeeded: configuration.maximumPacketSize)
         }
     }
 }

--- a/Sources/NIOSSH/Role.swift
+++ b/Sources/NIOSSH/Role.swift
@@ -46,6 +46,17 @@ public enum SSHConnectionRole {
             return configuration.transportProtectionSchemes
         }
     }
+
+    /// The maximum size of a channel data payload this peer advertises it is willing to receive,
+    /// and against which inbound encrypted packets are bounded.
+    internal var maximumPacketSize: UInt32 {
+        switch self {
+        case .client(let configuration):
+            return UInt32(configuration.maximumPacketSize)
+        case .server(let configuration):
+            return UInt32(configuration.maximumPacketSize)
+        }
+    }
 }
 
 @available(*, unavailable)

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -36,6 +36,7 @@ public struct SSHClientConfiguration {
     ///
     /// - Precondition: Must be at least 32768 bytes, the uncompressed payload size
     ///   RFC 4253 §6.1 requires every implementation to support.
+    /// - Precondition: The packet size must leave 1024 bytes for headers and framing.
     public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
         didSet {
             precondition(

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -28,15 +28,14 @@ public struct SSHClientConfiguration {
 
     /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
     /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
-    /// when opening channels and bounds inbound encrypted packets. Defaults to
-    /// ``Constants/defaultMaximumChannelPacketSize``.
+    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17`.
     ///
     /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
     /// this value raises the window proportionally. The window is stored as an `Int32`, meaning
     /// values above ~33 MiB (`Int32.max / 64`) saturate the window.
     ///
-    /// - Precondition: Must be at least ``Constants/minimumChannelPacketSize`` (32768 bytes), the
-    ///   uncompressed payload size RFC 4253 §6.1 requires every implementation to support.
+    /// - Precondition: Must be at least 32768 bytes, the uncompressed payload size
+    ///   RFC 4253 §6.1 requires every implementation to support.
     public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
         didSet {
             precondition(

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -28,7 +28,7 @@ public struct SSHClientConfiguration {
 
     /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
     /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
-    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17`.
+    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17` (128 KiB).
     ///
     /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
     /// this value raises the window proportionally. The window is stored as an `Int32`, meaning

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -42,6 +42,10 @@ public struct SSHClientConfiguration {
                 self.maximumPacketSize >= Constants.minimumChannelPacketSize,
                 "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
             )
+            precondition(
+                self.maximumPacketSize <= Constants.maximumChannelPacketSize,
+                "maximumPacketSize must leave room for SSH framing and padding (RFC 4253 §6)."
+            )
         }
     }
 

--- a/Sources/NIOSSH/SSHClientConfiguration.swift
+++ b/Sources/NIOSSH/SSHClientConfiguration.swift
@@ -26,6 +26,26 @@ public struct SSHClientConfiguration {
     /// Supported data encryption algorithms
     public var transportProtectionSchemes: [NIOSSHTransportProtection.Type]
 
+    /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
+    /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
+    /// when opening channels and bounds inbound encrypted packets. Defaults to
+    /// ``Constants/defaultMaximumChannelPacketSize``.
+    ///
+    /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
+    /// this value raises the window proportionally. The window is stored as an `Int32`, meaning
+    /// values above ~33 MiB (`Int32.max / 64`) saturate the window.
+    ///
+    /// - Precondition: Must be at least ``Constants/minimumChannelPacketSize`` (32768 bytes), the
+    ///   uncompressed payload size RFC 4253 §6.1 requires every implementation to support.
+    public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
+        didSet {
+            precondition(
+                self.maximumPacketSize >= Constants.minimumChannelPacketSize,
+                "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
+            )
+        }
+    }
+
     public init(
         userAuthDelegate: NIOSSHClientUserAuthenticationDelegate,
         serverAuthDelegate: NIOSSHClientServerAuthenticationDelegate,

--- a/Sources/NIOSSH/SSHPacketParser.swift
+++ b/Sources/NIOSSH/SSHPacketParser.swift
@@ -64,6 +64,10 @@ struct SSHPacketParser {
             maximumPacketSize >= Constants.minimumChannelPacketSize,
             "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
         )
+        precondition(
+            maximumPacketSize <= Constants.maximumChannelPacketSize,
+            "maximumPacketSize must leave room for SSH framing and padding (RFC 4253 §6)."
+        )
         self.isServer = isServer
         self.buffer = allocator.buffer(capacity: 0)
         self.state = .initialized

--- a/Sources/NIOSSH/SSHPacketParser.swift
+++ b/Sources/NIOSSH/SSHPacketParser.swift
@@ -36,14 +36,15 @@ struct SSHPacketParser {
     /// exchange. The encrypted path negotiates its own (larger) packet bound.
     static var maximumPlaintextPacketLength: UInt32 { 256 * 1024 }
 
-    /// The maximum length of an encrypted packet, i.e. its `packet_length` field once key
-    /// exchange has completed. Includes headroom for the SSH framing and padding (RFC 4253 §6).
-    static var maximumEncryptedPacketLength: UInt32 { Constants.maximumChannelPacketSize + 1024 }
-
     private let isServer: Bool
     private var buffer: ByteBuffer
     private var state: State
     private(set) var sequenceNumber: UInt32
+
+    /// The maximum length of an encrypted packet, i.e. its `packet_length` field once key exchange
+    /// has completed. This is the connection's configured maximum channel packet size plus headroom
+    /// for the SSH framing and padding (RFC 4253 §6) that wraps a maximum-size channel data payload.
+    private let maximumEncryptedPacketLength: UInt32
 
     /// The number of preamble lines a client has discarded while waiting for the identification
     /// string, bounded by `maximumPreambleLineCount`.
@@ -54,11 +55,21 @@ struct SSHPacketParser {
         self.buffer.readerIndex
     }
 
-    init(isServer: Bool, allocator: ByteBufferAllocator) {
+    init(
+        isServer: Bool,
+        allocator: ByteBufferAllocator,
+        maximumPacketSize: UInt32 = UInt32(Constants.defaultMaximumChannelPacketSize)
+    ) {
+        precondition(
+            maximumPacketSize >= Constants.minimumChannelPacketSize,
+            "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
+        )
         self.isServer = isServer
         self.buffer = allocator.buffer(capacity: 0)
         self.state = .initialized
         self.sequenceNumber = 0
+        // Add headroom for the SSH framing and padding (RFC 4253 §6).
+        self.maximumEncryptedPacketLength = maximumPacketSize + 1024
         self.preambleLineCount = 0
     }
 
@@ -287,10 +298,10 @@ struct SSHPacketParser {
         let length = self.buffer.getInteger(at: self.buffer.readerIndex, as: UInt32.self)!
 
         // Reject an oversized encrypted packet before we commit to buffering toward it.
-        guard length <= Self.maximumEncryptedPacketLength else {
+        guard length <= self.maximumEncryptedPacketLength else {
             throw NIOSSHError.protocolViolation(
                 protocolName: "transport",
-                violation: "encrypted packet length \(length) exceeds \(Self.maximumEncryptedPacketLength) bytes"
+                violation: "encrypted packet length \(length) exceeds \(self.maximumEncryptedPacketLength) bytes"
             )
         }
 
@@ -298,11 +309,11 @@ struct SSHPacketParser {
     }
 
     private mutating func parsePlaintext(length: UInt32) throws -> SSHMessage? {
-        // Reject an oversized cleartext packet before committing to buffering it.
+        // Reject an oversized plaintext packet before committing to buffering it.
         guard length <= Self.maximumPlaintextPacketLength else {
             throw NIOSSHError.protocolViolation(
                 protocolName: "transport",
-                violation: "cleartext packet length \(length) exceeds \(Self.maximumPlaintextPacketLength) bytes"
+                violation: "plaintext packet length \(length) exceeds \(Self.maximumPlaintextPacketLength) bytes"
             )
         }
 

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -31,15 +31,14 @@ public struct SSHServerConfiguration {
 
     /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
     /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
-    /// when opening channels and bounds inbound encrypted packets. Defaults to
-    /// ``Constants/defaultMaximumChannelPacketSize``.
+    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17`.
     ///
     /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
     /// this value raises the window proportionally. The window is stored as an `Int32`, meaning
     /// values above ~33 MiB (`Int32.max / 64`) saturate the window.
     ///
-    /// - Precondition: Must be at least ``Constants/minimumChannelPacketSize`` (32768 bytes), the
-    ///   uncompressed payload size RFC 4253 §6.1 requires every implementation to support.
+    /// - Precondition: Must be at least 32768 bytes, the uncompressed payload size
+    ///   RFC 4253 §6.1 requires every implementation to support.
     public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
         didSet {
             precondition(

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -39,6 +39,7 @@ public struct SSHServerConfiguration {
     ///
     /// - Precondition: Must be at least 32768 bytes, the uncompressed payload size
     ///   RFC 4253 §6.1 requires every implementation to support.
+    /// - Precondition: The packet size must leave 1024 bytes for headers and framing.
     public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
         didSet {
             precondition(

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -45,6 +45,10 @@ public struct SSHServerConfiguration {
                 self.maximumPacketSize >= Constants.minimumChannelPacketSize,
                 "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
             )
+            precondition(
+                self.maximumPacketSize <= Constants.maximumChannelPacketSize,
+                "maximumPacketSize must leave room for SSH framing and padding (RFC 4253 §6)."
+            )
         }
     }
 

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -31,7 +31,7 @@ public struct SSHServerConfiguration {
 
     /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
     /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
-    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17`.
+    /// when opening channels and bounds inbound encrypted packets. Defaults to `1 << 17`  (128 KiB).
     ///
     /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
     /// this value raises the window proportionally. The window is stored as an `Int32`, meaning

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -29,6 +29,26 @@ public struct SSHServerConfiguration {
     /// Supported data encryption algorithms
     public var transportProtectionSchemes: [NIOSSHTransportProtection.Type]
 
+    /// The maximum size, in bytes, of a channel data payload this peer is willing to receive (the
+    /// "maximum packet size" of an SSH channel, RFC 4254 §5.1). It is advertised to the remote peer
+    /// when opening channels and bounds inbound encrypted packets. Defaults to
+    /// ``Constants/defaultMaximumChannelPacketSize``.
+    ///
+    /// The per-channel receive window we advertise is a fixed multiple of this value (64x), so raising
+    /// this value raises the window proportionally. The window is stored as an `Int32`, meaning
+    /// values above ~33 MiB (`Int32.max / 64`) saturate the window.
+    ///
+    /// - Precondition: Must be at least ``Constants/minimumChannelPacketSize`` (32768 bytes), the
+    ///   uncompressed payload size RFC 4253 §6.1 requires every implementation to support.
+    public var maximumPacketSize: Int = Constants.defaultMaximumChannelPacketSize {
+        didSet {
+            precondition(
+                self.maximumPacketSize >= Constants.minimumChannelPacketSize,
+                "maximumPacketSize must be at least \(Constants.minimumChannelPacketSize) bytes (RFC 4253 §6.1)"
+            )
+        }
+    }
+
     public init(
         hostKeys: [NIOSSHPrivateKey],
         userAuthDelegate: NIOSSHServerUserAuthenticationDelegate,

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -1550,7 +1550,8 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         )
         XCTAssertEqual(harness.flushedMessages.count, 1)
 
-        // The default window size is 1<<24 bytes. Sadly, we need a buffer that size.
+        // The default window size is based on Constants. Sadly, we need a buffer that size.
+        let defaultWindowSize = Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple
         let buffer = ByteBuffer.bigBuffer
 
         // We close locally the channel.
@@ -1570,7 +1571,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
             try harness.multiplexer.receiveMessage(
                 self.data(
                     peerChannelID: channelID!,
-                    data: buffer.getSlice(at: buffer.readerIndex, length: 1 << 23)!
+                    data: buffer.getSlice(at: buffer.readerIndex, length: defaultWindowSize / 2)!
                 )
             )
         )

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -187,7 +187,8 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         let multiplexer = SSHChannelMultiplexer(
             delegate: delegate,
             allocator: delegate.allocator,
-            childChannelInitializer: initializer
+            childChannelInitializer: initializer,
+            maximumPacketSize: UInt32(Constants.defaultMaximumChannelPacketSize)
         )
         return TestHarness(delegate: delegate, multiplexer: multiplexer)
     }
@@ -202,7 +203,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
     private func openRequest(
         channelID: UInt32,
         initialWindowSize: UInt32 = 1 << 24,
-        maxPacketSize: UInt32 = 1 << 24
+        maxPacketSize: UInt32 = UInt32(Constants.defaultMaximumChannelPacketSize)
     ) -> SSHMessage {
         .channelOpen(
             .init(
@@ -218,7 +219,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         originalChannelID: UInt32,
         peerChannelID: UInt32,
         initialWindowSize: UInt32 = 1 << 24,
-        maxPacketSize: UInt32 = 1 << 24
+        maxPacketSize: UInt32 = UInt32(Constants.defaultMaximumChannelPacketSize)
     ) -> SSHMessage {
         .channelOpenConfirmation(
             .init(
@@ -256,8 +257,8 @@ final class ChildChannelMultiplexerTests: XCTestCase {
     func assertChannelOpen(_ message: SSHMessage?) -> UInt32? {
         switch message {
         case .some(.channelOpen(let message)):
-            XCTAssertEqual(message.maximumPacketSize, 1 << 24)
-            XCTAssertEqual(message.initialWindowSize, 1 << 24)
+            XCTAssertEqual(message.maximumPacketSize, UInt32(Constants.defaultMaximumChannelPacketSize))
+            XCTAssertEqual(message.initialWindowSize, UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple))
             return message.senderChannel
 
         case let fallback:
@@ -271,8 +272,8 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         switch message {
         case .some(.channelOpenConfirmation(let message)):
             XCTAssertEqual(message.recipientChannel, recipientChannel)
-            XCTAssertEqual(message.maximumPacketSize, 1 << 24)
-            XCTAssertEqual(message.initialWindowSize, 1 << 24)
+            XCTAssertEqual(message.maximumPacketSize, UInt32(Constants.defaultMaximumChannelPacketSize))
+            XCTAssertEqual(message.initialWindowSize, UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple))
             return message.senderChannel
 
         case let fallback:
@@ -1402,7 +1403,9 @@ final class ChildChannelMultiplexerTests: XCTestCase {
             )
         )
 
-        // The default window size is 1<<24 bytes. Sadly, we need a buffer that size.
+        // The default window size is based on the `Constants`. Sadly, we need a buffer that size.
+        let defaultWindowSize = UInt32(Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple)
+        let defaultWindowSizeHalf = defaultWindowSize / 2
         let buffer = ByteBuffer.bigBuffer
 
         // We're going to write one byte short.
@@ -1411,7 +1414,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
             try harness.multiplexer.receiveMessage(
                 self.data(
                     peerChannelID: channelID!,
-                    data: buffer.getSlice(at: buffer.readerIndex, length: (1 << 23) - 1)!
+                    data: buffer.getSlice(at: buffer.readerIndex, length: Int(defaultWindowSizeHalf - 1))!
                 )
             )
         )
@@ -1437,14 +1440,14 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         // Now issue a read. This triggers an outbound message.
         channel.read()
         XCTAssertEqual(harness.flushedMessages.count, 2)
-        self.assertWindowAdjust(harness.flushedMessages.last, recipientChannel: 1, delta: 1 << 23)
+        self.assertWindowAdjust(harness.flushedMessages.last, recipientChannel: 1, delta: defaultWindowSizeHalf)
 
         // Now issue a really big read. Again, there's no autoread, so this does nothing.
         XCTAssertNoThrow(
             try harness.multiplexer.receiveMessage(
                 self.data(
                     peerChannelID: channelID!,
-                    data: buffer.getSlice(at: buffer.readerIndex, length: 1 << 24)!
+                    data: buffer.getSlice(at: buffer.readerIndex, length: Int(defaultWindowSize))!
                 )
             )
         )
@@ -1453,7 +1456,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         // Issue the read. A new outbound message with a bigger window increment.
         channel.read()
         XCTAssertEqual(harness.flushedMessages.count, 3)
-        self.assertWindowAdjust(harness.flushedMessages.last, recipientChannel: 1, delta: 1 << 24)
+        self.assertWindowAdjust(harness.flushedMessages.last, recipientChannel: 1, delta: defaultWindowSize)
 
         // Finally, issue an excessively large read. This should cause an error.
         XCTAssertNoThrow(try harness.multiplexer.receiveMessage(self.data(peerChannelID: channelID!, data: buffer)))
@@ -1486,7 +1489,8 @@ final class ChildChannelMultiplexerTests: XCTestCase {
             )
         )
 
-        // The default window size is 1<<24 bytes. Sadly, we need a buffer that size.
+        // The default window size is based on Constants. Sadly, we need a buffer that size.
+        let defaultWindowSize = Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple
         let buffer = ByteBuffer.bigBuffer
 
         // We're going to write the whole window.
@@ -1495,7 +1499,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
             try harness.multiplexer.receiveMessage(
                 self.data(
                     peerChannelID: channelID!,
-                    data: buffer.getSlice(at: buffer.readerIndex, length: 1 << 24)!
+                    data: buffer.getSlice(at: buffer.readerIndex, length: defaultWindowSize)!
                 )
             )
         )
@@ -2171,10 +2175,11 @@ final class ChildChannelMultiplexerTests: XCTestCase {
 }
 
 extension ByteBuffer {
-    /// A buffer `(1 << 24) + 1` bytes large.
+    /// A buffer `Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple + 1` bytes large.
     fileprivate static let bigBuffer: ByteBuffer = {
-        // The default window size is 1<<24 bytes. Sadly, we need a buffer that size.
+        let size = Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple
+        // The default window size is `size` bytes. Sadly, we need a buffer that size.
         // We store it in a static so that we don't have to re-create it for every test.
-        ByteBuffer(repeating: 0, count: (1 << 24) + 1)
+        return ByteBuffer(repeating: 0, count: size + 1)
     }()
 }

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -258,7 +258,10 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         switch message {
         case .some(.channelOpen(let message)):
             XCTAssertEqual(message.maximumPacketSize, UInt32(Constants.defaultMaximumChannelPacketSize))
-            XCTAssertEqual(message.initialWindowSize, UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple))
+            XCTAssertEqual(
+                message.initialWindowSize,
+                UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple)
+            )
             return message.senderChannel
 
         case let fallback:
@@ -273,7 +276,10 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         case .some(.channelOpenConfirmation(let message)):
             XCTAssertEqual(message.recipientChannel, recipientChannel)
             XCTAssertEqual(message.maximumPacketSize, UInt32(Constants.defaultMaximumChannelPacketSize))
-            XCTAssertEqual(message.initialWindowSize, UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple))
+            XCTAssertEqual(
+                message.initialWindowSize,
+                UInt32(Constants.defaultMaximumChannelPacketSize) * UInt32(Constants.channelWindowSizePacketMultiple)
+            )
             return message.senderChannel
 
         case let fallback:
@@ -1404,7 +1410,9 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         )
 
         // The default window size is based on the `Constants`. Sadly, we need a buffer that size.
-        let defaultWindowSize = UInt32(Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple)
+        let defaultWindowSize = UInt32(
+            Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple
+        )
         let defaultWindowSizeHalf = defaultWindowSize / 2
         let buffer = ByteBuffer.bigBuffer
 

--- a/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
+++ b/Tests/NIOSSHTests/ChildChannelMultiplexerTests.swift
@@ -1550,7 +1550,7 @@ final class ChildChannelMultiplexerTests: XCTestCase {
         )
         XCTAssertEqual(harness.flushedMessages.count, 1)
 
-        // The default window size is based on Constants. Sadly, we need a buffer that size.
+        // The default window size is 8 MB. Sadly, we need a buffer that size.
         let defaultWindowSize = Constants.defaultMaximumChannelPacketSize * Constants.channelWindowSizePacketMultiple
         let buffer = ByteBuffer.bigBuffer
 

--- a/Tests/NIOSSHTests/SSHPacketParserTests.swift
+++ b/Tests/NIOSSHTests/SSHPacketParserTests.swift
@@ -375,6 +375,66 @@ final class SSHPacketParserTests: XCTestCase {
         XCTAssertThrowsError(try parser.nextPacket())
     }
 
+    func testEncryptedPacketCapTracksConfiguredMaximumPacketSize() throws {
+        func feedFirstBlock(maximumPacketSize: UInt32, injectedPacketSize: UInt32) throws -> SSHMessage? {
+            var parser = SSHPacketParser(
+                isServer: false,
+                allocator: ByteBufferAllocator(),
+                maximumPacketSize: maximumPacketSize
+            )
+            self.feedVersion(to: &parser)
+
+            let inboundEncryptionKey = SymmetricKey(size: .bits128)
+            let protection = TestTransportProtection(
+                initialKeys: .init(
+                    initialInboundIV: [],
+                    initialOutboundIV: [],
+                    inboundEncryptionKey: inboundEncryptionKey,
+                    outboundEncryptionKey: inboundEncryptionKey,
+                    inboundMACKey: SymmetricKey(size: .bits128),
+                    outboundMACKey: SymmetricKey(size: .bits128)
+                )
+            )
+            parser.addEncryption(protection)
+
+            // One cipher block whose first 4 (big-endian) bytes decode to `length`. We only feed the
+            // first block, so once the length is accepted the parser parks waiting for the body.
+            var plaintextBlock = ByteBufferAllocator().buffer(capacity: 128)
+            plaintextBlock.writeInteger(injectedPacketSize)
+            plaintextBlock.writeBytes([UInt8](repeating: 0, count: 124))
+            let keyBuffer = inboundEncryptionKey.withUnsafeBytes { ByteBuffer(bytes: $0) }
+            var ciphertext = InsecureEncryptionAlgorithm.encrypt(key: keyBuffer, plaintext: plaintextBlock)
+            parser.append(bytes: &ciphertext)
+
+            return try parser.nextPacket()
+        }
+
+        // Setting the RFC minimum is a valid configuration.
+        XCTAssertNoThrow(
+            try feedFirstBlock(
+                maximumPacketSize: UInt32(Constants.minimumChannelPacketSize),
+                injectedPacketSize: UInt32(Constants.minimumChannelPacketSize)
+            )
+        )
+
+        // The default is greater than the minimum and a packet of its size is not accepted when using the minimum.
+        XCTAssertGreaterThan(Constants.defaultMaximumChannelPacketSize, Constants.minimumChannelPacketSize)
+        XCTAssertThrowsError(
+            try feedFirstBlock(
+                maximumPacketSize: UInt32(Constants.minimumChannelPacketSize),
+                injectedPacketSize: UInt32(Constants.defaultMaximumChannelPacketSize)
+            )
+        )
+
+        // The default is also a valid configuration.
+        XCTAssertNoThrow(
+            try feedFirstBlock(
+                maximumPacketSize: UInt32(Constants.defaultMaximumChannelPacketSize),
+                injectedPacketSize: UInt32(Constants.defaultMaximumChannelPacketSize)
+            )
+        )
+    }
+
     func testReadVersionWithExtraLinesOnClient() throws {
         var parser = SSHPacketParser(isServer: false, allocator: ByteBufferAllocator())
 


### PR DESCRIPTION
### Motivation

The advertised max packet size was not configurable and used a
relatively high hard-code default.

### Modifications

* Configurable max packet size and lower default.
* Base window size on the configured max packet size to allow space for 64 packets.

### Results

More configurability.