### PR TITLE
Limit client auth attempts

### DIFF
--- a/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
+++ b/Sources/NIOSSH/Connection State Machine/Operations/AcceptsUserAuthMessages.swift
@@ -138,6 +138,8 @@ extension AcceptsUserAuthMessages {
             return SSHMultiMessage(.userAuthFailure(message))
         case .publicKeyOK(let message):
             return SSHMultiMessage(.userAuthPKOK(message))
+        case .disconnect(let disconnect):
+            return SSHMultiMessage(.disconnect(disconnect))
         }
     }
 

--- a/Sources/NIOSSH/Constants.swift
+++ b/Sources/NIOSSH/Constants.swift
@@ -38,4 +38,9 @@ public enum Constants: Sendable {
         [
             AES256GCMOpenSSHTransportProtection.self, AES128GCMOpenSSHTransportProtection.self,
         ]
+
+    /// The default value for `SSHServerConfiguration.maxAuthAttempts`: the maximum number of
+    /// `SSH_MSG_USERAUTH_REQUEST` messages a server processes on a single connection before
+    /// disconnecting the client.
+    static let defaultMaxAuthAttempts = 1024
 }

--- a/Sources/NIOSSH/SSHServerConfiguration.swift
+++ b/Sources/NIOSSH/SSHServerConfiguration.swift
@@ -53,6 +53,12 @@ public struct SSHServerConfiguration {
         }
     }
 
+    /// The maximum number of `SSH_MSG_USERAUTH_REQUEST` messages the server will process on a
+    /// single connection before disconnecting the client. Every request counts, including
+    /// authentication probes. Defaults to 1024; set to `Int.max` to effectively disable the limit.
+    /// Must be positive: a value of 0 or less disconnects every client on its first request.
+    public var maxAuthAttempts: Int? = nil
+
     public init(
         hostKeys: [NIOSSHPrivateKey],
         userAuthDelegate: NIOSSHServerUserAuthenticationDelegate,

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationMethod.swift
@@ -278,6 +278,7 @@ enum NIOSSHUserAuthenticationResponseMessage {
     case success
     case failure(SSHMessage.UserAuthFailureMessage)
     case publicKeyOK(SSHMessage.UserAuthPKOKMessage)
+    case disconnect(SSHMessage.DisconnectMessage)
 }
 
 extension NIOSSHUserAuthenticationResponseMessage {

--- a/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
+++ b/Sources/NIOSSH/User Authentication/UserAuthenticationStateMachine.swift
@@ -20,17 +20,32 @@ struct UserAuthenticationStateMachine {
     private let loop: EventLoop
     private var sessionID: ByteBuffer
 
-    // TODO: The server SHOULD limit the number of authentication attempts the client may make.
+    /// The maximum number of `SSH_MSG_USERAUTH_REQUEST` messages this server will process before
+    /// disconnecting. Taken from `SSHServerConfiguration`; `.max` for clients, which never enforce it.
+    private let maxAuthAttempts: Int
+
     init(role: SSHConnectionRole, loop: EventLoop, sessionID: ByteBuffer) {
         self.state = .idle
         self.delegate = UserAuthDelegate(role: role)
         self.loop = loop
         self.sessionID = sessionID
+        switch role {
+        case .server(let configuration):
+            self.maxAuthAttempts = configuration.maxAuthAttempts ?? Constants.defaultMaxAuthAttempts
+        case .client:
+            self.maxAuthAttempts = .max
+        }
     }
 
     fileprivate static let serviceName: String = "ssh-userauth"
 
     fileprivate static let nextServiceName: String = "ssh-connection"
+
+    private static let tooManyTriesDisconnect = SSHMessage.DisconnectMessage(
+        reason: 11,  // SSH_DISCONNECT_BY_APPLICATION
+        description: "Too many authentication failures",
+        tag: ""
+    )
 }
 
 extension UserAuthenticationStateMachine {
@@ -38,8 +53,8 @@ extension UserAuthenticationStateMachine {
         /// In this state, we have not received any user auth messages yet
         case idle
         case awaitingServiceAcceptance
-        case awaitingNextRequest
-        case awaitingResponses(Int)
+        case awaitingNextRequest(attempts: Int)
+        case awaitingResponses(attempts: Int, pending: Int)
         case authenticationSucceeded
         case authenticationFailed
     }
@@ -81,8 +96,8 @@ extension UserAuthenticationStateMachine {
             return nil
 
         case (.server, .authenticationFailed):
-            // TODO(cory): We should be limiting the maximum number of authentication attempts.
-            preconditionFailure("Servers cannot enter authentication failed")
+            // We have already emitted a disconnect; ignore anything still in flight.
+            return nil
 
         case (.client, _):
             // Clients may never receive user service request messages.
@@ -107,7 +122,7 @@ extension UserAuthenticationStateMachine {
             }
 
             // Cool, we can begin the auth dance.
-            self.state = .awaitingNextRequest
+            self.state = .awaitingNextRequest(attempts: 0)
             return self.requestNextAuthRequest(methods: .all, delegate: delegate)
         case (.client, .authenticationSucceeded):
             // We should ignore all further auth messages in this state.
@@ -147,12 +162,20 @@ extension UserAuthenticationStateMachine {
         }
 
         switch (self.delegate, self.state) {
-        case (.server(let delegate), .awaitingNextRequest):
-            self.state = .awaitingResponses(1)
+        case (.server(let delegate), .awaitingNextRequest(let attempts)):
+            guard attempts < self.maxAuthAttempts else {
+                self.state = .authenticationFailed
+                return self.loop.makeSucceededFuture(.disconnect(Self.tooManyTriesDisconnect))
+            }
+            self.state = .awaitingResponses(attempts: attempts + 1, pending: 1)
             return self.nextAuthResponse(request: message, delegate: delegate)
 
-        case (.server(let delegate), .awaitingResponses(let pending)):
-            self.state = .awaitingResponses(pending + 1)
+        case (.server(let delegate), .awaitingResponses(let attempts, let pending)):
+            guard attempts < self.maxAuthAttempts else {
+                self.state = .authenticationFailed
+                return self.loop.makeSucceededFuture(.disconnect(Self.tooManyTriesDisconnect))
+            }
+            self.state = .awaitingResponses(attempts: attempts + 1, pending: pending + 1)
             return self.nextAuthResponse(request: message, delegate: delegate)
 
         case (.server, .idle), (.server, .awaitingServiceAcceptance):
@@ -166,8 +189,8 @@ extension UserAuthenticationStateMachine {
             return nil
 
         case (.server, .authenticationFailed):
-            // TODO(cory): We should be limiting the maximum number of authentication attempts.
-            preconditionFailure("Servers cannot enter authentication failed")
+            // We have already emitted a disconnect; ignore anything still in flight.
+            return nil
 
         case (.client, _):
             // Clients may never receive user auth request messages.
@@ -214,9 +237,9 @@ extension UserAuthenticationStateMachine {
         _ message: SSHMessage.UserAuthFailureMessage
     ) throws -> EventLoopFuture<SSHMessage.UserAuthRequestMessage?>? {
         switch (self.delegate, self.state) {
-        case (.client(let delegate), .awaitingResponses(let responseCount)):
+        case (.client(let delegate), .awaitingResponses(let attempts, let responseCount)):
             // Ok, the server didn't like that much. Let's try another one.
-            self.state = .awaitingNextRequest
+            self.state = .awaitingNextRequest(attempts: attempts)
             precondition(responseCount == 1, "We don't support parallel authentication attempts yet!")
             return self.requestNextAuthRequest(methods: .init(message), delegate: delegate)
         case (.client, .authenticationSucceeded):
@@ -288,7 +311,7 @@ extension UserAuthenticationStateMachine {
         switch (self.delegate, self.state) {
         case (.server, .awaitingServiceAcceptance):
             precondition(message.service == Self.serviceName)
-            self.state = .awaitingNextRequest
+            self.state = .awaitingNextRequest(attempts: 0)
         case (.server, .idle):
             preconditionFailure("Cannot accept a service that hasn't been requested")
         case (.server, .awaitingNextRequest),
@@ -303,8 +326,8 @@ extension UserAuthenticationStateMachine {
 
     mutating func sendUserAuthRequest(_: SSHMessage.UserAuthRequestMessage) {
         switch (self.delegate, self.state) {
-        case (.client, .awaitingNextRequest):
-            self.state = .awaitingResponses(1)
+        case (.client, .awaitingNextRequest(let attempts)):
+            self.state = .awaitingResponses(attempts: attempts, pending: 1)
         case (.client, .idle),
             (.client, .awaitingServiceAcceptance):
             preconditionFailure("Sent an auth request without asking us first")
@@ -330,11 +353,11 @@ extension UserAuthenticationStateMachine {
             preconditionFailure("Server sent an auth response prior to receiving an auth request")
         case (.server, .awaitingNextRequest):
             preconditionFailure("Too many auth responses sent")
-        case (.server, .awaitingResponses(let responseCount)):
+        case (.server, .awaitingResponses(let attempts, let responseCount)):
             if responseCount > 1 {
-                self.state = .awaitingResponses(responseCount - 1)
+                self.state = .awaitingResponses(attempts: attempts, pending: responseCount - 1)
             } else {
-                self.state = .awaitingNextRequest
+                self.state = .awaitingNextRequest(attempts: attempts)
             }
         case (.server, .authenticationSucceeded):
             preconditionFailure("Authentication already succeeded, further messages are unnecessary.")
@@ -380,13 +403,13 @@ extension UserAuthenticationStateMachine {
             preconditionFailure("Server sent an auth response prior to receiving an auth request")
         case (.server, .awaitingNextRequest):
             preconditionFailure("Too many auth responses sent")
-        case (.server, .awaitingResponses(let responseCount)):
+        case (.server, .awaitingResponses(let attempts, let responseCount)):
             if success {
                 self.state = .authenticationSucceeded
             } else if responseCount > 1 {
-                self.state = .awaitingResponses(responseCount - 1)
+                self.state = .awaitingResponses(attempts: attempts, pending: responseCount - 1)
             } else {
-                self.state = .awaitingNextRequest
+                self.state = .awaitingNextRequest(attempts: attempts)
             }
         case (.server, .authenticationSucceeded):
             preconditionFailure("Authentication already succeeded, further messages are unnecessary.")

--- a/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
+++ b/Tests/NIOSSHTests/UserAuthenticationStateMachineTests.swift
@@ -257,6 +257,8 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
                 XCTFail("Unexpected public key ok")
             case .success(.success):
                 XCTFail("Unexpected success")
+            case .success(.disconnect):
+                XCTFail("Unexpected disconnect")
             case .failure(let error):
                 XCTFail("Unexpected error: \(error)")
             }
@@ -285,6 +287,8 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
                 XCTFail("Unexpected public key ok")
             case .success(.failure):
                 XCTFail("Unexpected failure")
+            case .success(.disconnect):
+                XCTFail("Unexpected disconnect")
             case .failure(let error):
                 XCTFail("Unexpected error: \(error)")
             }
@@ -314,6 +318,8 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
                 XCTFail("Unexpected success")
             case .success(.failure):
                 XCTFail("Unexpected failure")
+            case .success(.disconnect):
+                XCTFail("Unexpected disconnect")
             case .failure(let error):
                 XCTFail("Unexpected error: \(error)")
             }
@@ -321,6 +327,37 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
         self.loop.run()
 
         XCTAssertEqual(message.value, expecting)
+    }
+
+    func expectAuthRequestToDisconnectSynchronously(
+        request: SSHMessage.UserAuthRequestMessage,
+        expectingDisconnect disconnect: SSHMessage.DisconnectMessage,
+        stateMachine: inout UserAuthenticationStateMachine
+    ) throws {
+        let future = try assertNoThrowWithValue(try stateMachine.receiveUserAuthRequest(request))
+        XCTAssertNotNil(future)
+        guard let future = future else {
+            return
+        }
+
+        let result = NIOLoopBoundBox<SSHMessage.DisconnectMessage?>(nil, eventLoop: future.eventLoop)
+        future.whenComplete {
+            switch $0 {
+            case .success(.disconnect(let d)):
+                result.value = d
+            case .success(.failure):
+                XCTFail("Unexpected plain failure")
+            case .success(.publicKeyOK):
+                XCTFail("Unexpected public key ok")
+            case .success(.success):
+                XCTFail("Unexpected success")
+            case .failure(let error):
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+        self.loop.run()
+
+        XCTAssertEqual(result.value, disconnect)
     }
 
     func testBasicHappyClientFlow() throws {
@@ -1173,5 +1210,225 @@ final class UserAuthenticationStateMachineTests: XCTestCase {
 
         // Let's say we got a success. Happy path!
         XCTAssertNoThrow(try stateMachine.receiveUserAuthSuccess())
+    }
+
+    func testServerDisconnectsAfterMaxAuthAttempts() throws {
+        let maxAttempts = 4
+        var config: SSHServerConfiguration = .init(
+            hostKeys: [self.hostKey],
+            userAuthDelegate: DenyAllServerAuthDelegate(),
+        )
+        config.maxAuthAttempts = maxAttempts
+        var stateMachine = UserAuthenticationStateMachine(
+            role: .server(config),
+            loop: self.loop,
+            sessionID: self.sessionID
+        )
+
+        let serviceAccept = SSHMessage.ServiceAcceptMessage(service: "ssh-userauth")
+        XCTAssertNoThrow(
+            try self.serviceRequested(service: "ssh-userauth", nextMessage: serviceAccept, stateMachine: &stateMachine)
+        )
+        stateMachine.sendServiceAccept(serviceAccept)
+
+        let authRequest = SSHMessage.UserAuthRequestMessage(
+            username: "foo",
+            service: "ssh-connection",
+            method: .password("bar")
+        )
+        let failure = SSHMessage.UserAuthFailureMessage(
+            authentications: ["password", "publickey", "hostbased"],
+            partialSuccess: false
+        )
+
+        // The cap allows exactly `maxAttempts` requests; each is rejected one at a time.
+        for _ in 0..<maxAttempts {
+            try self.expectAuthRequestToFailSynchronously(
+                request: authRequest,
+                expecting: failure,
+                stateMachine: &stateMachine
+            )
+            stateMachine.sendUserAuthFailure(failure)
+        }
+
+        // The next request trips the cap and disconnects.
+        let disconnect = SSHMessage.DisconnectMessage(
+            reason: 11,
+            description: "Too many authentication failures",
+            tag: ""
+        )
+        try self.expectAuthRequestToDisconnectSynchronously(
+            request: authRequest,
+            expectingDisconnect: disconnect,
+            stateMachine: &stateMachine
+        )
+    }
+
+    func testServerIgnoresRequestsAfterDisconnect() throws {
+        let maxAttempts = 4
+        var config: SSHServerConfiguration = .init(
+            hostKeys: [self.hostKey],
+            userAuthDelegate: DenyAllServerAuthDelegate(),
+        )
+        config.maxAuthAttempts = maxAttempts
+        var stateMachine = UserAuthenticationStateMachine(
+            role: .server(config),
+            loop: self.loop,
+            sessionID: self.sessionID
+        )
+
+        let serviceAccept = SSHMessage.ServiceAcceptMessage(service: "ssh-userauth")
+        XCTAssertNoThrow(
+            try self.serviceRequested(service: "ssh-userauth", nextMessage: serviceAccept, stateMachine: &stateMachine)
+        )
+        stateMachine.sendServiceAccept(serviceAccept)
+
+        let authRequest = SSHMessage.UserAuthRequestMessage(
+            username: "foo",
+            service: "ssh-connection",
+            method: .password("bar")
+        )
+        let failure = SSHMessage.UserAuthFailureMessage(
+            authentications: ["password", "publickey", "hostbased"],
+            partialSuccess: false
+        )
+
+        for _ in 0..<maxAttempts {
+            try self.expectAuthRequestToFailSynchronously(
+                request: authRequest,
+                expecting: failure,
+                stateMachine: &stateMachine
+            )
+            stateMachine.sendUserAuthFailure(failure)
+        }
+
+        // Trip the cap.
+        let disconnect = SSHMessage.DisconnectMessage(
+            reason: 11,
+            description: "Too many authentication failures",
+            tag: ""
+        )
+        try self.expectAuthRequestToDisconnectSynchronously(
+            request: authRequest,
+            expectingDisconnect: disconnect,
+            stateMachine: &stateMachine
+        )
+
+        // A late in-flight request must be ignored, not trapped.
+        XCTAssertNil(try stateMachine.receiveUserAuthRequest(authRequest))
+
+        // A late service request must also be ignored.
+        XCTAssertNil(try stateMachine.receiveServiceRequest(.init(service: "ssh-userauth")))
+    }
+
+    func testProbesCountTowardTheCap() throws {
+        let maxAttempts = 4
+        var config: SSHServerConfiguration = .init(
+            hostKeys: [self.hostKey],
+            userAuthDelegate: DenyAllServerAuthDelegate(),
+        )
+        config.maxAuthAttempts = maxAttempts
+        var stateMachine = UserAuthenticationStateMachine(
+            role: .server(config),
+            loop: self.loop,
+            sessionID: self.sessionID
+        )
+
+        let serviceAccept = SSHMessage.ServiceAcceptMessage(service: "ssh-userauth")
+        XCTAssertNoThrow(
+            try self.serviceRequested(service: "ssh-userauth", nextMessage: serviceAccept, stateMachine: &stateMachine)
+        )
+        stateMachine.sendServiceAccept(serviceAccept)
+
+        let password = SSHMessage.UserAuthRequestMessage(
+            username: "foo",
+            service: "ssh-connection",
+            method: .password("bar")
+        )
+        let failure = SSHMessage.UserAuthFailureMessage(
+            authentications: ["password", "publickey", "hostbased"],
+            partialSuccess: false
+        )
+
+        // Use up all but one of the budget with rejected password attempts.
+        for _ in 0..<(maxAttempts - 1) {
+            try self.expectAuthRequestToFailSynchronously(
+                request: password,
+                expecting: failure,
+                stateMachine: &stateMachine
+            )
+            stateMachine.sendUserAuthFailure(failure)
+        }
+
+        // A public-key probe (no signature) returns PK_OK — and still consumes the last unit of budget.
+        let probeKey = NIOSSHPrivateKey(p256Key: .init()).publicKey
+        let probe = SSHMessage.UserAuthRequestMessage(
+            username: "foo",
+            service: "ssh-connection",
+            method: .publicKey(.known(key: probeKey, signature: nil))
+        )
+        try self.expectAuthRequestToReturnPKOKSynchronously(
+            request: probe,
+            expecting: .init(key: probeKey),
+            stateMachine: &stateMachine
+        )
+        stateMachine.sendUserAuthPKOK(.init(key: probeKey))
+
+        // Budget is now exhausted: the next request — even another probe — disconnects.
+        let disconnect = SSHMessage.DisconnectMessage(
+            reason: 11,
+            description: "Too many authentication failures",
+            tag: ""
+        )
+        try self.expectAuthRequestToDisconnectSynchronously(
+            request: probe,
+            expectingDisconnect: disconnect,
+            stateMachine: &stateMachine
+        )
+    }
+
+    func testPipelinedRequestsCannotBypassTheCap() throws {
+        let maxAttempts = 4
+        var config: SSHServerConfiguration = .init(
+            hostKeys: [self.hostKey],
+            userAuthDelegate: DenyAllServerAuthDelegate(),
+        )
+        config.maxAuthAttempts = maxAttempts
+        var stateMachine = UserAuthenticationStateMachine(
+            role: .server(config),
+            loop: self.loop,
+            sessionID: self.sessionID
+        )
+
+        let serviceAccept = SSHMessage.ServiceAcceptMessage(service: "ssh-userauth")
+        XCTAssertNoThrow(
+            try self.serviceRequested(service: "ssh-userauth", nextMessage: serviceAccept, stateMachine: &stateMachine)
+        )
+        stateMachine.sendServiceAccept(serviceAccept)
+
+        let authRequest = SSHMessage.UserAuthRequestMessage(
+            username: "foo",
+            service: "ssh-connection",
+            method: .password("bar")
+        )
+
+        // Pipeline the entire budget WITHOUT answering any request, so each is counted on
+        // enqueue while all prior ones are still in flight (pending grows to the full budget).
+        // This proves the cap gates on the accumulated `attempts`, not on `pending`.
+        for _ in 0..<maxAttempts {
+            XCTAssertNotNil(try stateMachine.receiveUserAuthRequest(authRequest))
+        }
+
+        // The next enqueue trips the cap synchronously, even though nothing has been answered.
+        let disconnect = SSHMessage.DisconnectMessage(
+            reason: 11,
+            description: "Too many authentication failures",
+            tag: ""
+        )
+        try self.expectAuthRequestToDisconnectSynchronously(
+            request: authRequest,
+            expectingDisconnect: disconnect,
+            stateMachine: &stateMachine
+        )
     }
 }


### PR DESCRIPTION
### Motivation

Clients can send as many (parallel) requests as they want. The server should put an upper bound on the attempts.

### Modifications

Cap attempts at a configurable limit (default 1024). This limit tracks all messages not just auth failures, but is chosen relatively high.

### Results

Bound client auth attempts.